### PR TITLE
Receive order on input and trigger

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.6.5-mailroom-7.1.22
+----------
+ * Add support to receive order on input and tigger and any metadata object in trigger
+
 1.6.4-mailroom-7.1.22
 ----------
  * Update goflow version for v0.1.1-goflow-0.144.3

--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,4 @@ go 1.17
 
 replace github.com/nyaruka/gocommon => github.com/Ilhasoft/gocommon v1.16.2-weni
 
-replace github.com/nyaruka/goflow => github.com/weni-ai/goflow v0.1.1-goflow-0.144.3
+replace github.com/nyaruka/goflow => github.com/weni-ai/goflow v0.1.2-goflow-0.144.3

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLD
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
-github.com/weni-ai/goflow v0.1.1-goflow-0.144.3 h1:h5JvjuIo7xhAenKl4m+E0OPIhYw0IETBUYqZEgpZlCw=
-github.com/weni-ai/goflow v0.1.1-goflow-0.144.3/go.mod h1:o0xaVWP9qNcauBSlcNLa79Fm2oCPV+BDpheFRa/D40c=
+github.com/weni-ai/goflow v0.1.2-goflow-0.144.3 h1:vcxe2AQO3MpaDMosP4mzUuQsBwRHd+abpQ68QA5XGT4=
+github.com/weni-ai/goflow v0.1.2-goflow-0.144.3/go.mod h1:o0xaVWP9qNcauBSlcNLa79Fm2oCPV+BDpheFRa/D40c=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
add order as property to `@input`.
usage:
`@input.order`
`@input.order.catalog_id`
etc..

now trigger.params can receive any metadata object, allowing receive order too:

`@trigger.params.order.catalog_id`

`@trigger.params.order.product_items.0.product_retailer_id`
etc...