### PR TITLE
Fix/wenichats msg history selection

### DIFF
--- a/services/tickets/wenichats/service.go
+++ b/services/tickets/wenichats/service.go
@@ -157,7 +157,8 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 	}
 
 	// get messages for history
-	after := session.Runs()[0].CreatedOn()
+	startMargin := -time.Second * 1
+	after := session.Runs()[0].CreatedOn().Add(startMargin)
 	cx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	msgs, err := models.SelectContactMessages(cx, db, int(contact.ID()), after)

--- a/services/tickets/wenichats/service_test.go
+++ b/services/tickets/wenichats/service_test.go
@@ -266,7 +266,7 @@ func TestOpenAndForward(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{"id", "uuid", "text", "high_priority", "created_on", "modified_on", "sent_on", "queued_on", "direction", "status", "visibility", "msg_type", "msg_count", "error_count", "next_attempt", "external_id", "attachments", "metadata", "broadcast_id", "channel_id", "contact_id", "contact_urn_id", "org_id", "topup_id"})
 
-	after, err := time.Parse("2006-01-02T15:04:05", "2019-10-07T15:21:30")
+	after, err := time.Parse("2006-01-02T15:04:05", "2019-10-07T15:21:29")
 	assert.NoError(t, err)
 
 	mock.ExpectQuery("SELECT").


### PR DESCRIPTION
When the flow starts with a trigger, the message is created first and then the flow run is created, this means that selecting messages from the flow run creation does not bring the trigger message. This fix prevents this first message from being omitted from the history.