### PR TITLE
Wenichats history after onbody param

### DIFF
--- a/services/tickets/wenichats/service.go
+++ b/services/tickets/wenichats/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buger/jsonparser"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 
@@ -156,9 +157,26 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 		return nil, errors.Wrap(err, "failed to create wenichats room webhook")
 	}
 
-	// get messages for history
-	startMargin := -time.Second * 1
-	after := session.Runs()[0].CreatedOn().Add(startMargin)
+	historyAfter, _ := jsonparser.GetString([]byte(body), "history_after")
+
+	var after time.Time
+	if historyAfter != "" {
+		// get msgs for history based on history_after param inside ticket body
+		after1, err1 := time.Parse(time.DateTime, historyAfter)
+		after2, err2 := time.Parse(time.RFC3339, historyAfter)
+		if err1 != nil && err2 != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to parse history_after from value from format DateTime or RFC3339. Expected format \"2006-01-02 15:04:05\" or \"2006-01-02T15:04:05Z\", current value is \"%s\"", historyAfter))
+		}
+		if err1 != nil {
+			after = after2
+		} else {
+			after = after1
+		}
+	} else {
+		// get messages for history, based on first session run start time
+		startMargin := -time.Second * 1
+		after = session.Runs()[0].CreatedOn().Add(startMargin)
+	}
 	cx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	msgs, err := models.SelectContactMessages(cx, db, int(contact.ID()), after)

--- a/services/tickets/wenichats/service.go
+++ b/services/tickets/wenichats/service.go
@@ -162,8 +162,8 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 	var after time.Time
 	if historyAfter != "" {
 		// get msgs for history based on history_after param inside ticket body
-		after1, err1 := time.Parse(time.DateTime, historyAfter)
-		after2, err2 := time.Parse(time.RFC3339, historyAfter)
+		after1, err1 := time.Parse("2006-01-02 15:04:05", historyAfter)
+		after2, err2 := time.Parse("2006-01-02T15:04:05Z", historyAfter)
 		if err1 != nil && err2 != nil {
 			return nil, errors.Wrap(err, fmt.Sprintf("failed to parse history_after from value from format DateTime or RFC3339. Expected format \"2006-01-02 15:04:05\" or \"2006-01-02T15:04:05Z\", current value is \"%s\"", historyAfter))
 		}


### PR DESCRIPTION
with this PR, when open a ticket for wenichats if body has attribute `history_after` with value in format DateTime, all messages after this date will be considered to send history

```
{
    "history_after": "2024-03-28 15:00:00"
}
```