### PR TITLE
feat: close wenichats ticket on history failure

### DIFF
--- a/services/tickets/wenichats/service.go
+++ b/services/tickets/wenichats/service.go
@@ -204,7 +204,11 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 			logHTTP(flows.NewHTTPLog(trace, flows.HTTPStatusFromCode, s.redactor))
 		}
 		if err != nil {
-			return nil, errors.Wrap(err, "error calling wenichats to create a history message")
+			_, _, err = s.restClient.CloseRoom(newRoom.UUID)
+			if err != nil {
+				return nil, errors.Wrap(err, "error closing ticket after failing to send history messages to wenichats")
+			}
+			return nil, errors.Wrap(err, "error calling wenichats to create a history message, closing newly opened ticket")
 		}
 	}
 


### PR DESCRIPTION
Close the remote ticket if a history message fails to be sent, since with this failure the ticket is not opened internally and an error is returned.