### PR TITLE
use the match of contactID and ticketUUID as twillioflex identity

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.52.0
+----------
+ * twillio-flex use the match of contactID and ticketUUID as identity for user
+
 1.51.0
 ----------
  * Add support for catalog message in whatsapp messages

--- a/services/tickets/twilioflex/service.go
+++ b/services/tickets/twilioflex/service.go
@@ -93,8 +93,11 @@ func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *htt
 func (s *service) Open(session flows.Session, topic *flows.Topic, body string, assignee *flows.User, logHTTP flows.HTTPLogCallback) (*flows.Ticket, error) {
 	ticket := flows.OpenTicket(s.ticketer, topic, body, assignee)
 	contact := session.Contact()
+
+	userIdentity := fmt.Sprintf("%d_%s", contact.ID(), ticket.UUID())
+
 	chatUser := &CreateChatUserParams{
-		Identity:     fmt.Sprint(contact.ID()),
+		Identity:     userIdentity,
 		FriendlyName: contact.Name(),
 	}
 	contactUser, trace, err := s.restClient.FetchUser(chatUser.Identity)
@@ -116,7 +119,7 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 
 	flexChannelParams := &CreateFlexChannelParams{
 		FlexFlowSid:          s.restClient.flexFlowSid,
-		Identity:             fmt.Sprint(contact.ID()),
+		Identity:             userIdentity,
 		ChatUserFriendlyName: contact.Name(),
 		ChatFriendlyName:     contact.Name(),
 	}
@@ -186,7 +189,7 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 
 	go func() {
 		time.Sleep(time.Second * time.Duration(historyDelay))
-		SendHistory(session, contact.ID(), newFlexChannel, logHTTP, s.restClient, s.redactor)
+		SendHistory(session, contact.ID(), string(ticket.UUID()), newFlexChannel, logHTTP, s.restClient, s.redactor)
 	}()
 
 	ticket.SetExternalID(newFlexChannel.Sid)
@@ -194,7 +197,7 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 }
 
 func (s *service) Forward(ticket *models.Ticket, msgUUID flows.MsgUUID, text string, attachments []utils.Attachment, logHTTP flows.HTTPLogCallback) error {
-	identity := fmt.Sprint(ticket.ContactID())
+	identity := fmt.Sprintf("%d_%s", ticket.ContactID(), ticket.UUID())
 
 	if len(attachments) > 0 {
 		mediaAttachements := []CreateMediaParams{}
@@ -295,7 +298,8 @@ func (s *service) Reopen(tickets []*models.Ticket, logHTTP flows.HTTPLogCallback
 	return errors.New("Twilio Flex ticket type doesn't support reopening")
 }
 
-func SendHistory(session flows.Session, contactID flows.ContactID, newFlexChannel *FlexChannel, logHTTP flows.HTTPLogCallback, restClient *Client, redactor utils.Redactor) {
+func SendHistory(session flows.Session, contactID flows.ContactID, ticketUUID string, newFlexChannel *FlexChannel, logHTTP flows.HTTPLogCallback, restClient *Client, redactor utils.Redactor) {
+	userIdentity := fmt.Sprintf("%d_%s", contactID, ticketUUID)
 	after := session.Runs()[0].CreatedOn().Add(time.Second * -1)
 	cx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -320,7 +324,7 @@ func SendHistory(session flows.Session, contactID flows.ContactID, newFlexChanne
 			DateCreated: msg.CreatedOn().Format(time.RFC3339),
 		}
 		if msg.Direction() == "I" {
-			m.From = fmt.Sprint(contactID)
+			m.From = userIdentity
 			headerWebhookEnabled := http.Header{"X-Twilio-Webhook-Enabled": []string{"True"}}
 			_, trace, err = restClient.CreateMessage(m, headerWebhookEnabled)
 		} else {

--- a/services/tickets/twilioflex/service_test.go
+++ b/services/tickets/twilioflex/service_test.go
@@ -41,13 +41,15 @@ func TestOpenAndForward(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 
 	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
-		"https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/1234567": {
+		"https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/1234567_e7187099-7d38-4f60-955c-325957214c42": {
 			httpx.NewMockResponse(404, nil, `{
 				"code": 20404,
 				"message": "The requested resource /Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/1234567 was not found",
 				"more_info": "https://www.twilio.com/docs/errors/20404",
 				"status": 404
 			}`),
+		},
+		"https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/1234567_59d74b86-3e2f-4a93-aece-b05d2fdcde0c": {
 			httpx.NewMockResponse(200, nil, `{
 				"is_notifiable": null,
 				"date_updated": "2022-03-08T22:18:23Z",
@@ -640,6 +642,7 @@ func TestSendHistory(t *testing.T) {
 	twilioflex.SendHistory(
 		session,
 		2,
+		"1488d3ac-9cf6-4811-ae4c-2b7b31e5550a",
 		&twilioflex.FlexChannel{Sid: "CH6442c09c93ba4d13966fa42e9b78f620"},
 		logger.Log,
 		restClient,

--- a/services/tickets/twilioflex/service_test.go
+++ b/services/tickets/twilioflex/service_test.go
@@ -90,6 +90,25 @@ func TestOpenAndForward(t *testing.T) {
 						"user_bindings": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f/Bindings"
 				}
 			}`),
+			httpx.NewMockResponse(201, nil, `{
+				"is_notifiable": null,
+				"date_updated": "2022-03-08T22:18:23Z",
+				"is_online": null,
+				"friendly_name": "dummy user",
+				"account_sid": "AC81d44315e19372138bdaffcc13cf3b94",
+				"url": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f",
+				"date_created": "2022-03-08T22:18:23Z",
+				"role_sid": "RL6f3f490b35534130845f98202673ffb9",
+				"sid": "USf4015a97250d482889459f8e8819e09f",
+				"attributes": "{}",
+				"service_sid": "IS38067ec392f1486bb6e4de4610f26fb3",
+				"joined_channels_count": 0,
+				"identity": "10000",
+				"links": {
+						"user_channels": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f/Channels",
+						"user_bindings": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f/Bindings"
+				}
+			}`),
 		},
 		"https://flex-api.twilio.com/v1/Channels": {
 			httpx.NewMockResponse(201, nil, `{
@@ -318,6 +337,54 @@ func TestOpenAndForward(t *testing.T) {
 				"was_edited": false
 			}`),
 		},
+		"https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/10000_59d74b86-3e2f-4a93-aece-b05d2fdcde0c": {
+			httpx.NewMockResponse(404, nil, `{
+				"code": 20404,
+				"message": "The requested resource /Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/1234567 was not found",
+				"more_info": "https://www.twilio.com/docs/errors/20404",
+				"status": 404
+			}`),
+			httpx.NewMockResponse(200, nil, `{
+				"is_notifiable": null,
+				"date_updated": "2022-03-08T22:18:23Z",
+				"is_online": null,
+				"friendly_name": "dummy user",
+				"account_sid": "AC81d44315e19372138bdaffcc13cf3b94",
+				"url": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f",
+				"date_created": "2022-03-08T22:18:23Z",
+				"role_sid": "RL6f3f490b35534130845f98202673ffb9",
+				"sid": "USf4015a97250d482889459f8e8819e09f",
+				"attributes": "{}",
+				"service_sid": "IS38067ec392f1486bb6e4de4610f26fb3",
+				"joined_channels_count": 0,
+				"identity": "10000",
+				"links": {
+						"user_channels": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f/Channels",
+						"user_bindings": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f/Bindings"
+				}
+			}`),
+		},
+		"https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/10000_645eee60-7e84-4a9e-ade3-4fce01ae28f1": {
+			httpx.NewMockResponse(200, nil, `{
+				"is_notifiable": null,
+				"date_updated": "2022-03-08T22:18:23Z",
+				"is_online": null,
+				"friendly_name": "dummy user",
+				"account_sid": "AC81d44315e19372138bdaffcc13cf3b94",
+				"url": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f",
+				"date_created": "2022-03-08T22:18:23Z",
+				"role_sid": "RL6f3f490b35534130845f98202673ffb9",
+				"sid": "USf4015a97250d482889459f8e8819e09f",
+				"attributes": "{}",
+				"service_sid": "IS38067ec392f1486bb6e4de4610f26fb3",
+				"joined_channels_count": 0,
+				"identity": "10000",
+				"links": {
+						"user_channels": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f/Channels",
+						"user_bindings": "https://chat.twilio.com/v2/Services/IS38067ec392f1486bb6e4de4610f26fb3/Users/USf4015a97250d482889459f8e8819e09f/Bindings"
+				}
+			}`),
+		},
 	}))
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "twilioflex"))
@@ -378,7 +445,7 @@ func TestOpenAndForward(t *testing.T) {
 	logger = &flows.HTTPLogger{}
 	err = svc.Forward(dbTicket, flows.MsgUUID("4fa340ae-1fb0-4666-98db-2177fe9bf31c"), "It's urgent", nil, logger.Log)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(logger.Logs))
+	assert.Equal(t, 2, len(logger.Logs))
 	test.AssertSnapshot(t, "forward_message", logger.Logs[0].Request)
 
 	dbTicket2 := models.NewTicket("645eee60-7e84-4a9e-ade3-4fce01ae28f1", testdata.Org1.ID, testdata.Cathy.ID, testdata.Twilioflex.ID, "CH180fa48ef2ba40a08fa5c9fb5c8ddd99", testdata.DefaultTopic.ID, "Where are my cookies?", models.NilUserID, map[string]interface{}{
@@ -394,7 +461,7 @@ func TestOpenAndForward(t *testing.T) {
 	}
 	err = svc.Forward(dbTicket2, flows.MsgUUID("5ga340ae-1fb0-4666-98db-2177fe9bf31c"), "It's urgent", attachments, logger.Log)
 	assert.NoError(t, err)
-	assert.Equal(t, 7, len(logger.Logs))
+	assert.Equal(t, 8, len(logger.Logs))
 }
 
 func TestCloseAndReopen(t *testing.T) {

--- a/services/tickets/twilioflex/testdata/TestOpenAndForward_forward_message.snap
+++ b/services/tickets/twilioflex/testdata/TestOpenAndForward_forward_message.snap
@@ -1,10 +1,8 @@
-POST /v2/Services/****************/Channels/CH6442c09c93ba4d13966fa42e9b78f620/Messages HTTP/1.1
+POST /v2/Services/****************/Users/10000_59d74b86-3e2f-4a93-aece-b05d2fdcde0c HTTP/1.1
 Host: chat.twilio.com
 User-Agent: Go-http-client/1.1
-Content-Length: 112
+Content-Length: 0
 Authorization: Basic QUM4MWQ0NDMxNWUxOTM3MjEzOGJkYWZmY2MxM2NmM2I5NDp0b2tlbg==
 Content-Type: application/x-www-form-urlencoded
-X-Twilio-Webhook-Enabled: True
 Accept-Encoding: gzip
 
-Body=It%27s+urgent&ChannelSid=CH6442c09c93ba4d13966fa42e9b78f620&From=10000_59d74b86-3e2f-4a93-aece-b05d2fdcde0c

--- a/services/tickets/twilioflex/testdata/TestOpenAndForward_forward_message.snap
+++ b/services/tickets/twilioflex/testdata/TestOpenAndForward_forward_message.snap
@@ -1,10 +1,10 @@
 POST /v2/Services/****************/Channels/CH6442c09c93ba4d13966fa42e9b78f620/Messages HTTP/1.1
 Host: chat.twilio.com
 User-Agent: Go-http-client/1.1
-Content-Length: 75
+Content-Length: 112
 Authorization: Basic QUM4MWQ0NDMxNWUxOTM3MjEzOGJkYWZmY2MxM2NmM2I5NDp0b2tlbg==
 Content-Type: application/x-www-form-urlencoded
 X-Twilio-Webhook-Enabled: True
 Accept-Encoding: gzip
 
-Body=It%27s+urgent&ChannelSid=CH6442c09c93ba4d13966fa42e9b78f620&From=10000
+Body=It%27s+urgent&ChannelSid=CH6442c09c93ba4d13966fa42e9b78f620&From=10000_59d74b86-3e2f-4a93-aece-b05d2fdcde0c

--- a/services/tickets/twilioflex/testdata/TestOpenAndForward_open_ticket.snap
+++ b/services/tickets/twilioflex/testdata/TestOpenAndForward_open_ticket.snap
@@ -1,4 +1,4 @@
-POST /v2/Services/****************/Users/1234567 HTTP/1.1
+POST /v2/Services/****************/Users/1234567_59d74b86-3e2f-4a93-aece-b05d2fdcde0c HTTP/1.1
 Host: chat.twilio.com
 User-Agent: Go-http-client/1.1
 Content-Length: 0

--- a/services/tickets/twilioflex/testdata/event_callback.json
+++ b/services/tickets/twilioflex/testdata/event_callback.json
@@ -40,7 +40,7 @@
     "headers": {
       "Authorization": "Token 123456789"
     },
-    "body": "EventType=onMessageSent&InstanceSid=IS38067ec392f1486bb6e4de4610f26fb3&Attributes=%7B%7D&DateCreated=2022-03-10T23%3A56%3A43.412Z&Index=1&From=teste_2Etwilioflex&MessageSid=IM4b440f124820414b8f500a1235532ac1&AccountSid=AC81d44315e19372138bdaffcc13cf3b94&Source=SDK&ChannelSid=CH1880a9cde40c4dbb88dd97fc3aedac08&ClientIdentity=10000&RetryCount=0&WebhookType=webhook&Body=We can help&WebhookSid=WH99d1f1895a7c4e6fa10ac5e8ac0c2242",
+    "body": "EventType=onMessageSent&InstanceSid=IS38067ec392f1486bb6e4de4610f26fb3&Attributes=%7B%7D&DateCreated=2022-03-10T23%3A56%3A43.412Z&Index=1&From=teste_2Etwilioflex&MessageSid=IM4b440f124820414b8f500a1235532ac1&AccountSid=AC81d44315e19372138bdaffcc13cf3b94&Source=SDK&ChannelSid=CH1880a9cde40c4dbb88dd97fc3aedac08&ClientIdentity=10000_$cathy_ticket_uuid$&RetryCount=0&WebhookType=webhook&Body=We can help&WebhookSid=WH99d1f1895a7c4e6fa10ac5e8ac0c2242",
     "status": 200,
     "response": {
       "status": "handled"

--- a/services/tickets/twilioflex/web.go
+++ b/services/tickets/twilioflex/web.go
@@ -74,16 +74,18 @@ func handleEventCallback(ctx context.Context, rt *runtime.Runtime, r *http.Reque
 		return err, http.StatusBadRequest, nil
 	}
 
+	identity := fmt.Sprintf("%d_%s", ticket.ContactID(), ticket.UUID())
+
 	switch request.EventType {
 	case "onMessageSent":
-		if request.ClientIdentity != fmt.Sprint(ticket.ContactID()) && request.From != fmt.Sprint(ticket.ContactID()) { // prevent echo message
+		if request.ClientIdentity != identity && request.From != identity { // prevent echo message
 			_, err = tickets.SendReply(ctx, rt, ticket, request.Body, []*tickets.File{})
 			if err != nil {
 				return err, http.StatusBadRequest, nil
 			}
 		}
 	case "onMediaMessageSent":
-		if request.ClientIdentity != fmt.Sprint(ticket.ContactID()) && request.From != fmt.Sprint(ticket.ContactID()) { // prevent echo message
+		if request.ClientIdentity != identity && request.From != identity { // prevent echo message
 			config := ticketer.Config
 			authToken := config(configurationAuthToken)
 			accountSid := config(configurationAccountSid)


### PR DESCRIPTION
to avoid many repetition of chat channels with the same identity