### PR TITLE
fix wenichats service parseTime adding new expected format

### DIFF
--- a/services/tickets/wenichats/service.go
+++ b/services/tickets/wenichats/service.go
@@ -315,6 +315,7 @@ func parseTime(historyAfter string) (time.Time, error) {
 	formats := []string{
 		"2006-01-02 15:04:05",
 		"2006-01-02T15:04:05Z",
+		"2006-01-02 15:04:05-07:00",
 	}
 
 	for _, format := range formats {

--- a/web/ticket/testdata/open.json
+++ b/web/ticket/testdata/open.json
@@ -103,11 +103,11 @@
       "ticketer_id": 7,
       "topic_id": 1,
       "assignee_id": 0,
-      "extra": "{\"history_after\":\"2025-01-01 00:00:00\"}"
+      "extra": "{\"history_after\":\"2025-01-01 00:00:00-00:00\"}"
     },
     "status": 200,
     "response": {
-      "body": "{\"history_after\":\"2025-01-01 00:00:00\"}",
+      "body": "{\"history_after\":\"2025-01-01 00:00:00-00:00\"}",
       "external_id": "8ecb1e4a-b457-4645-a161-e2b02ddffa88",
       "ticketer": {
           "name": "Weni Chats",


### PR DESCRIPTION
putting back the time parse format for "2006-01-02 15:04:05-07:00"