### PR TITLE
feat: Set default high priority for outgoing WPP messages

### DIFF
--- a/core/handlers/msg_wpp_created_test.go
+++ b/core/handlers/msg_wpp_created_test.go
@@ -183,8 +183,8 @@ func TestMsgWppCreated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count)
 
-	// One high priority message for George
+	// Two high priority message for George
 	count, err = redis.Int(rc.Do("zcard", fmt.Sprintf("msgs:%s|10/1", testdata.TwilioChannel.UUID)))
 	assert.NoError(t, err)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 2, count)
 }

--- a/core/handlers/msg_wpp_created_test.go
+++ b/core/handlers/msg_wpp_created_test.go
@@ -160,7 +160,7 @@ func TestMsgWppCreated(t *testing.T) {
 					Count: 2,
 				},
 				{
-					SQL:   "SELECT COUNT(*) FROM msgs_msg WHERE text='Hi' AND contact_id = $1 AND attachments[1] = $2 AND status = 'Q' AND high_priority = FALSE",
+					SQL:   "SELECT COUNT(*) FROM msgs_msg WHERE text='Hi' AND contact_id = $1 AND attachments[1] = $2 AND status = 'Q' AND high_priority = TRUE",
 					Args:  []interface{}{testdata.George.ID, "image/png:https://foo.bar.com/images/image1.png"},
 					Count: 1,
 				},

--- a/core/handlers/msg_wpp_created_test.go
+++ b/core/handlers/msg_wpp_created_test.go
@@ -178,13 +178,13 @@ func TestMsgWppCreated(t *testing.T) {
 	rc := rp.Get()
 	defer rc.Close()
 
-	// Cathy should have 1 batch of queued messages at high priority
+	// Cathy should have 2 batch of queued messages at high priority
 	count, err := redis.Int(rc.Do("zcard", fmt.Sprintf("msgs:%s|10/1", testdata.TwilioChannel.UUID)))
 	assert.NoError(t, err)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 2, count)
 
-	// One bulk for George
-	count, err = redis.Int(rc.Do("zcard", fmt.Sprintf("msgs:%s|10/0", testdata.TwilioChannel.UUID)))
+	// One high priority message for George
+	count, err = redis.Int(rc.Do("zcard", fmt.Sprintf("msgs:%s|10/1", testdata.TwilioChannel.UUID)))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 }

--- a/core/models/msgs.go
+++ b/core/models/msgs.go
@@ -561,7 +561,7 @@ func newOutgoingMsgWpp(rt *runtime.Runtime, org *Org, channel *Channel, contactI
 	m := &msg.m
 	m.UUID = msgWpp.UUID()
 	m.Text = msgWpp.Text()
-	m.HighPriority = false
+	m.HighPriority = true // by default, we send wpp messages as high priority since they're usually sent as an agent response
 	m.Direction = DirectionOut
 	m.Status = MsgStatusQueued
 	m.Visibility = VisibilityVisible
@@ -680,6 +680,7 @@ func newOutgoingMsgWpp(rt *runtime.Runtime, org *Org, channel *Channel, contactI
 		if msgWpp.Templating() != nil {
 			metadata["templating"] = msgWpp.Templating()
 			m.Template = null.String(msgWpp.Templating().Template().Name)
+			m.HighPriority = false // template messages are usually sent for a large number of contacts, so we don't want to block other messages
 		}
 		if len(msgWpp.Products()) > 0 {
 			metadata["products"] = msgWpp.Products()


### PR DESCRIPTION
- Templates messages should have low priority since they are usually sent in large batches