### PR TITLE
Refactor contact loading to use LoadContacts method across multiple handlers

### DIFF
--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -221,7 +221,7 @@ func handleTimedEvent(ctx context.Context, rt *runtime.Runtime, eventType string
 	}
 
 	// load our contact
-	contacts, err := models.LoadContactsBasic(ctx, rt.ReadonlyDB, oa, []models.ContactID{event.ContactID})
+	contacts, err := models.LoadContacts(ctx, rt.ReadonlyDB, oa, []models.ContactID{event.ContactID})
 	if err != nil {
 		return errors.Wrapf(err, "error loading contact")
 	}

--- a/core/tasks/ivr/worker.go
+++ b/core/tasks/ivr/worker.go
@@ -79,7 +79,7 @@ func HandleFlowStartBatch(bg context.Context, rt *runtime.Runtime, batch *models
 	}
 
 	// ok, we can initiate calls for the remaining contacts
-	contacts, err := models.LoadContactsBasic(ctx, rt.ReadonlyDB, oa, contactIDs)
+	contacts, err := models.LoadContacts(ctx, rt.ReadonlyDB, oa, contactIDs)
 	if err != nil {
 		return errors.Wrapf(err, "error loading contacts")
 	}

--- a/web/ivr/ivr.go
+++ b/web/ivr/ivr.go
@@ -254,7 +254,7 @@ func handleFlow(ctx context.Context, rt *runtime.Runtime, r *http.Request, w htt
 	}
 
 	// load our contact
-	contacts, err := models.LoadContactsBasic(ctx, rt.ReadonlyDB, oa, []models.ContactID{conn.ContactID()})
+	contacts, err := models.LoadContacts(ctx, rt.ReadonlyDB, oa, []models.ContactID{conn.ContactID()})
 	if err != nil {
 		return channel, conn, provider.WriteErrorResponse(w, errors.Wrapf(err, "no such contact"))
 	}


### PR DESCRIPTION
- Some cases like a child flow completion, were causing the parent flow to not have group and ticket information about the contact, this was caused due to LoadContactsBasic nature, where groups and tickets are not loaded to improve performance
- Since these are required fields to a proper flow execution, we've modified back to use LoadContacts in all Flow related contact loads (even IVR ones, though they are not used currently), keeping the LoadContactsBasic only to broadcasts contact loads.