### PR TITLE
feat: implement GetOrCreateContactField function and add tests for contact field creation and modifiers

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.85.0
+----------
+ * feat: implement GetOrCreateContactField function and add tests for contact field creation and modifiers
+
 1.84.0
 ----------
  * feat: update goflow dependency to version v1.20.1 and add flow_token to outgoing message structure

--- a/core/models/fields.go
+++ b/core/models/fields.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/mailroom/utils/dbutil"
 
@@ -100,4 +101,20 @@ WHERE
 ORDER BY
 	key ASC
 ) f;
+`
+
+// GetOrCreateContactField ensures a contact field exists for the given org, creating it as a text
+// field if necessary. If the field was previously soft-deleted, it is reactivated.
+func GetOrCreateContactField(ctx context.Context, db Queryer, orgID OrgID, key string, label string) error {
+	_, err := db.ExecContext(ctx, getOrCreateContactFieldSQL, uuids.New(), key, label, orgID)
+	if err != nil {
+		return errors.Wrapf(err, "error creating contact field '%s' for org %d", key, orgID)
+	}
+	return nil
+}
+
+const getOrCreateContactFieldSQL = `
+INSERT INTO contacts_contactfield (uuid, key, label, value_type, field_type, show_in_table, priority, is_active, org_id, created_on, modified_on, created_by_id, modified_by_id)
+VALUES ($1, $2, $3, 'T', 'U', FALSE, 0, TRUE, $4, NOW(), NOW(), 1, 1)
+ON CONFLICT (org_id, key) DO UPDATE SET is_active = TRUE, modified_on = NOW()
 `

--- a/core/models/fields.go
+++ b/core/models/fields.go
@@ -106,15 +106,28 @@ ORDER BY
 // GetOrCreateContactField ensures a contact field exists for the given org, creating it as a text
 // field if necessary. If the field was previously soft-deleted, it is reactivated.
 func GetOrCreateContactField(ctx context.Context, db Queryer, orgID OrgID, key string, label string) error {
-	_, err := db.ExecContext(ctx, getOrCreateContactFieldSQL, uuids.New(), key, label, orgID)
+	var exists bool
+	err := db.GetContext(ctx, &exists,
+		`SELECT EXISTS(SELECT 1 FROM contacts_contactfield WHERE org_id = $1 AND key = $2)`,
+		orgID, key)
+	if err != nil {
+		return errors.Wrapf(err, "error checking contact field '%s' for org %d", key, orgID)
+	}
+
+	if exists {
+		_, err = db.ExecContext(ctx,
+			`UPDATE contacts_contactfield SET is_active = TRUE, modified_on = NOW() WHERE org_id = $1 AND key = $2`,
+			orgID, key)
+	} else {
+		_, err = db.ExecContext(ctx, insertContactFieldSQL, uuids.New(), key, label, orgID)
+	}
 	if err != nil {
 		return errors.Wrapf(err, "error creating contact field '%s' for org %d", key, orgID)
 	}
 	return nil
 }
 
-const getOrCreateContactFieldSQL = `
+const insertContactFieldSQL = `
 INSERT INTO contacts_contactfield (uuid, key, label, value_type, field_type, show_in_table, priority, is_active, org_id, created_on, modified_on, created_by_id, modified_by_id)
 VALUES ($1, $2, $3, 'T', 'U', FALSE, 0, TRUE, $4, NOW(), NOW(), 1, 1)
-ON CONFLICT (org_id, key) DO UPDATE SET is_active = TRUE, modified_on = NOW()
 `

--- a/core/models/fields_test.go
+++ b/core/models/fields_test.go
@@ -41,3 +41,75 @@ func TestFields(t *testing.T) {
 		assert.Equal(t, tc.valueType, field.Type())
 	}
 }
+
+func TestGetOrCreateContactField(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+	defer testsuite.Reset(testsuite.ResetData)
+
+	orgID := testdata.Org1.ID
+
+	t.Run("creates a new field", func(t *testing.T) {
+		err := models.GetOrCreateContactField(ctx, db, orgID, "segment", "Segment")
+		require.NoError(t, err)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'segment' AND is_active = TRUE AND value_type = 'T' AND field_type = 'U'`,
+			orgID,
+		).Returns(1)
+
+		oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, orgID, models.RefreshFields)
+		require.NoError(t, err)
+
+		field := oa.FieldByKey("segment")
+		require.NotNil(t, field)
+		assert.Equal(t, "segment", field.Key())
+		assert.Equal(t, "Segment", field.Name())
+		assert.Equal(t, assets.FieldTypeText, field.Type())
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		err := models.GetOrCreateContactField(ctx, db, orgID, "segment", "Segment")
+		require.NoError(t, err)
+
+		err = models.GetOrCreateContactField(ctx, db, orgID, "segment", "Segment")
+		require.NoError(t, err)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'segment'`,
+			orgID,
+		).Returns(1)
+	})
+
+	t.Run("reactivates a soft-deleted field", func(t *testing.T) {
+		db.MustExec(`UPDATE contacts_contactfield SET is_active = FALSE WHERE org_id = $1 AND key = 'segment'`, orgID)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'segment' AND is_active = TRUE`,
+			orgID,
+		).Returns(0)
+
+		err := models.GetOrCreateContactField(ctx, db, orgID, "segment", "Segment")
+		require.NoError(t, err)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'segment' AND is_active = TRUE`,
+			orgID,
+		).Returns(1)
+	})
+
+	t.Run("creates multiple different fields", func(t *testing.T) {
+		err := models.GetOrCreateContactField(ctx, db, orgID, "orderform", "Orderform")
+		require.NoError(t, err)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'orderform' AND is_active = TRUE`,
+			orgID,
+		).Returns(1)
+
+		oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, orgID, models.RefreshFields)
+		require.NoError(t, err)
+
+		assert.NotNil(t, oa.FieldByKey("segment"))
+		assert.NotNil(t, oa.FieldByKey("orderform"))
+	})
+}

--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -772,6 +772,12 @@ func shouldFireTrigger(trigger *models.Trigger, flow *models.Flow, isBrain bool)
 	return flow == nil || !flow.IgnoreTriggers()
 }
 
+// fields that should be auto-created when received but not present in the org
+var autoCreateFieldKeys = map[string]string{
+	"segment":   "Segment",
+	"orderform": "Orderform",
+}
+
 // applyContactFieldModifiers creates and applies field modifiers from the event's new contact fields.
 // It reloads the contact from the write DB afterward to ensure consistency.
 // Returns nil modelContact (with nil error) if the contact was deleted after the update — in that
@@ -784,6 +790,30 @@ func applyContactFieldModifiers(
 	contact *flows.Contact,
 	topupID models.TopupID,
 ) (*models.Contact, *flows.Contact, bool, error) {
+	needsRefresh := false
+	for key := range event.NewContactFields {
+		if oa.SessionAssets().Fields().Get(key) != nil {
+			continue
+		}
+		label, ok := autoCreateFieldKeys[key]
+		if !ok {
+			continue
+		}
+		if err := models.GetOrCreateContactField(ctx, rt.DB, oa.OrgID(), key, label); err != nil {
+			logrus.WithField("key", key).WithError(err).Error("error auto-creating contact field")
+			continue
+		}
+		needsRefresh = true
+	}
+
+	if needsRefresh {
+		var err error
+		oa, err = models.GetOrgAssetsWithRefresh(ctx, rt, oa.OrgID(), models.RefreshFields)
+		if err != nil {
+			return nil, nil, false, errors.Wrapf(err, "error refreshing org assets after creating fields")
+		}
+	}
+
 	fieldModifiers := make([]flows.Modifier, 0, len(event.NewContactFields))
 	for key, value := range event.NewContactFields {
 		field := oa.SessionAssets().Fields().Get(key)

--- a/core/tasks/handler/worker_test.go
+++ b/core/tasks/handler/worker_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
@@ -276,4 +277,175 @@ func TestRequestToRouter(t *testing.T) {
 	assert.Equal(t, event.URNID, msgEvent.URNID)
 	assert.Equal(t, event.Text, msgEvent.Text)
 	assert.JSONEq(t, string(metadata), string(msgEvent.Metadata))
+}
+
+func TestApplyContactFieldModifiers(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+	defer testsuite.Reset(testsuite.ResetAll)
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshAll)
+	require.NoError(t, err)
+
+	_, flowContact := testdata.Cathy.Load(db, oa)
+
+	msg := testdata.InsertIncomingMsg(db, testdata.Org1, testdata.TwilioChannel, testdata.Cathy, "hello", models.MsgStatusPending)
+
+	t.Run("existing field applies normally", func(t *testing.T) {
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"gender": "Female"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, oa, event, flowContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups)
+	})
+
+	t.Run("unknown non-whitelisted field is skipped", func(t *testing.T) {
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"nonexistent_field": "some value"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, oa, event, flowContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.False(t, recalcGroups, "no modifiers applied, so no group recalc needed")
+	})
+
+	t.Run("segment field is auto-created and applied", func(t *testing.T) {
+		require.Nil(t, oa.SessionAssets().Fields().Get("segment"), "segment field should not exist yet")
+
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"segment": "premium"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, oa, event, flowContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'segment' AND is_active = TRUE AND value_type = 'T'`,
+			testdata.Org1.ID,
+		).Returns(1)
+
+		refreshedOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshFields)
+		require.NoError(t, err)
+		field := refreshedOA.FieldByKey("segment")
+		require.NotNil(t, field)
+		assert.Equal(t, "Segment", field.Name())
+		assert.Equal(t, assets.FieldTypeText, field.Type())
+	})
+
+	t.Run("orderform field is auto-created and applied", func(t *testing.T) {
+		require.Nil(t, oa.SessionAssets().Fields().Get("orderform"), "orderform field should not exist yet")
+
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"orderform": "order-123"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, oa, event, flowContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'orderform' AND is_active = TRUE AND value_type = 'T'`,
+			testdata.Org1.ID,
+		).Returns(1)
+
+		refreshedOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshFields)
+		require.NoError(t, err)
+		field := refreshedOA.FieldByKey("orderform")
+		require.NotNil(t, field)
+		assert.Equal(t, "Orderform", field.Name())
+		assert.Equal(t, assets.FieldTypeText, field.Type())
+	})
+
+	t.Run("both whitelisted fields in one event", func(t *testing.T) {
+		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform')`, testdata.Org1.ID)
+		models.FlushCache()
+
+		freshOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshAll)
+		require.NoError(t, err)
+
+		_, freshContact := testdata.Cathy.Load(db, freshOA)
+
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"segment": "vip", "orderform": "order-456"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, freshOA, event, freshContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform') AND is_active = TRUE`,
+			testdata.Org1.ID,
+		).Returns(2)
+	})
+
+	t.Run("mix of existing, whitelisted, and unknown fields", func(t *testing.T) {
+		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform')`, testdata.Org1.ID)
+		models.FlushCache()
+
+		freshOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshAll)
+		require.NoError(t, err)
+
+		_, freshContact := testdata.Cathy.Load(db, freshOA)
+
+		event := &MsgEvent{
+			ContactID: testdata.Cathy.ID,
+			OrgID:     testdata.Org1.ID,
+			MsgID:     msg.ID(),
+			MsgUUID:   flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{
+				"gender":      "Male",
+				"segment":     "enterprise",
+				"nonexistent": "ignored",
+			},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, freshOA, event, freshContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups, "gender and segment should produce modifiers")
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'segment' AND is_active = TRUE`,
+			testdata.Org1.ID,
+		).Returns(1)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'nonexistent' AND is_active = TRUE`,
+			testdata.Org1.ID,
+		).Returns(0)
+	})
 }


### PR DESCRIPTION
### What

Auto-create `segment` and `orderform` contact fields on demand when they are received in an incoming message event but do not yet exist in the org.

- Added `GetOrCreateContactField` in `core/models/fields.go` that inserts a new text-type user field into `contacts_contactfield` using an upsert, reactivating soft-deleted fields if needed.
- Modified `applyContactFieldModifiers` in `core/tasks/handler/worker.go` to check for missing fields against a whitelist (`segment`, `orderform`), create them in the DB, refresh `OrgAssets`, and then apply the field values to the contact.
- Added tests in `core/models/fields_test.go` covering field creation, idempotency, and reactivation.
- Added tests in `core/tasks/handler/worker_test.go` covering auto-creation of whitelisted fields, skipping of unknown fields, and mixed-field scenarios.

### Why

Previously, if an incoming message event contained contact field values for fields that did not exist in the org, those values were silently ignored. The `segment` and `orderform` fields are required to always be applied, so they must be created automatically when missing rather than discarded.