### PR TITLE
feat: enable stream support for channel versions >= 2

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.85.3
+----------
+* feat: enable stream support for channel versions >= 2
+
 1.85.2
 ----------
 * feat: check if is ab2(is_multi_agents) before publish sqs ticket event

--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/apex/log"
@@ -1096,7 +1097,7 @@ func requestToRouter(event *MsgEvent, rtConfig *runtime.Config, contact *flows.C
 	httpClient, httpRetries, _ := goflow.HTTP(rtConfig)
 
 	streamSupport := false
-	if fmt.Sprint(channel.Config()["version"]) == "2" {
+	if version, err := strconv.Atoi(fmt.Sprint(channel.Config()["version"])); err == nil && version >= 2 {
 		streamSupport = true
 	}
 

--- a/core/tasks/handler/worker_test.go
+++ b/core/tasks/handler/worker_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -165,7 +166,7 @@ func TestRequestToRouter(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 	defer testsuite.Reset(testsuite.ResetAll)
 
-	channel := testdata.InsertChannel(db, testdata.Org1, "TW", "Router Channel", []string{"tel"}, "SR", map[string]interface{}{"version": 2})
+	channel := testdata.InsertChannel(db, testdata.Org1, "TW", "Router Channel", []string{"tel"}, "SR", map[string]interface{}{"version": "2"})
 	contact := testdata.InsertContact(db, testdata.Org1, flows.ContactUUID(uuids.New()), "Router Contact", envs.Language("eng"))
 	urn := urns.URN("tel:+250700000010")
 	urnID := testdata.InsertContactURN(db, testdata.Org1, contact, urn, 1000)
@@ -277,6 +278,91 @@ func TestRequestToRouter(t *testing.T) {
 	assert.Equal(t, event.URNID, msgEvent.URNID)
 	assert.Equal(t, event.Text, msgEvent.Text)
 	assert.JSONEq(t, string(metadata), string(msgEvent.Metadata))
+}
+
+func TestRequestToRouterStreamSupportByVersion(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+	defer testsuite.Reset(testsuite.ResetAll)
+
+	contact := testdata.InsertContact(db, testdata.Org1, flows.ContactUUID(uuids.New()), "Stream Contact", envs.Language("eng"))
+	urn := urns.URN("tel:+250700000020")
+	urnID := testdata.InsertContactURN(db, testdata.Org1, contact, urn, 1000)
+
+	reqCh := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		reqCh <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt.Config.RouterBaseURL = server.URL
+	rt.Config.RouterAuthToken = "router-token"
+
+	tests := []struct {
+		name          string
+		config        map[string]interface{}
+		streamSupport bool
+	}{
+		{"version 0 as int disables stream support", map[string]interface{}{"version": 0}, false},
+		{"version 1 as int disables stream support", map[string]interface{}{"version": 1}, false},
+		{"version 2 as int enables stream support", map[string]interface{}{"version": 2}, true},
+		{"version 3 as int enables stream support", map[string]interface{}{"version": 3}, true},
+		{"version 10 as int enables stream support", map[string]interface{}{"version": 10}, true},
+		{"version 1 as string disables stream support", map[string]interface{}{"version": "1"}, false},
+		{"version 2 as string enables stream support", map[string]interface{}{"version": "2"}, true},
+		{"version 3 as string enables stream support", map[string]interface{}{"version": "3"}, true},
+		{"version 10 as string enables stream support", map[string]interface{}{"version": "10"}, true},
+		{"missing version disables stream support", map[string]interface{}{}, false},
+		{"non-numeric version disables stream support", map[string]interface{}{"version": "abc"}, false},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channel := testdata.InsertChannel(
+				db, testdata.Org1, "TW",
+				fmt.Sprintf("Router Channel %d", i),
+				[]string{"tel"}, "SR",
+				tt.config,
+			)
+
+			models.FlushCache()
+
+			oa, err := models.GetOrgAssets(ctx, rt, testdata.Org1.ID)
+			require.NoError(t, err)
+
+			channelModel := oa.ChannelByID(channel.ID)
+			require.NotNil(t, channelModel)
+
+			modelContact, err := models.LoadContact(ctx, db, oa, contact.ID)
+			require.NoError(t, err)
+
+			flowContact, err := modelContact.FlowContact(oa)
+			require.NoError(t, err)
+
+			event := &MsgEvent{
+				ContactID: contact.ID,
+				OrgID:     testdata.Org1.ID,
+				ChannelID: channel.ID,
+				MsgID:     flows.MsgID(123),
+				MsgUUID:   flows.MsgUUID(uuids.New()),
+				URN:       urn,
+				URNID:     urnID,
+				Text:      "hello router",
+			}
+
+			err = requestToRouter(event, rt.Config, flowContact, uuids.New(), channelModel)
+			require.NoError(t, err)
+
+			body := <-reqCh
+
+			var payload struct {
+				StreamSupport bool `json:"stream_support"`
+			}
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.Equal(t, tt.streamSupport, payload.StreamSupport)
+		})
+	}
 }
 
 func TestApplyContactFieldModifiers(t *testing.T) {


### PR DESCRIPTION
### What

Changes the condition that enables `stream_support` in router requests from "version is exactly `2`" to "version is `>= 2`", parsed numerically so the check works regardless of whether the value is stored as a string or a number in the channel config.

- `core/tasks/handler/worker.go`: replaces `fmt.Sprint(channel.Config()["version"]) == "2"` with `strconv.Atoi(fmt.Sprint(...))` and a `version >= 2` comparison.
- `core/tasks/handler/worker_test.go`: updates `TestRequestToRouter` so its `StreamSupport: true` assertion still holds, and adds `TestRequestToRouterStreamSupportByVersion`, a table-driven test covering int/string values, missing keys, and non-numeric inputs.

### Why

- Channels with versions newer than `2` should also receive `stream_support: true`; the previous strict-equality check excluded them.
- The `version` value in `channel.Config()` may come back as either a number or a string (e.g. after JSON round-trip through the DB). Coercing via `fmt.Sprint` and parsing with `strconv.Atoi` handles both shapes consistently and compares numerically, avoiding fragile lexicographic string comparisons (e.g. `"10" < "3"`).

Made with [Cursor](https://cursor.com)