### PR TITLE
feat: add email field support in contact field modifiers

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.85.4
+----------
+* feat: add email field support in contact field modifiers
+
 1.85.3
 ----------
 * feat: enable stream support for channel versions >= 2

--- a/core/models/fields_test.go
+++ b/core/models/fields_test.go
@@ -101,8 +101,16 @@ func TestGetOrCreateContactField(t *testing.T) {
 		err := models.GetOrCreateContactField(ctx, db, orgID, "orderform", "Orderform")
 		require.NoError(t, err)
 
+		err = models.GetOrCreateContactField(ctx, db, orgID, "email", "Email")
+		require.NoError(t, err)
+
 		testsuite.AssertQuery(t, db,
 			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'orderform' AND is_active = TRUE`,
+			orgID,
+		).Returns(1)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'email' AND is_active = TRUE`,
 			orgID,
 		).Returns(1)
 
@@ -111,5 +119,6 @@ func TestGetOrCreateContactField(t *testing.T) {
 
 		assert.NotNil(t, oa.FieldByKey("segment"))
 		assert.NotNil(t, oa.FieldByKey("orderform"))
+		assert.NotNil(t, oa.FieldByKey("email"))
 	})
 }

--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -777,6 +777,7 @@ func shouldFireTrigger(trigger *models.Trigger, flow *models.Flow, isBrain bool)
 var autoCreateFieldKeys = map[string]string{
 	"segment":   "Segment",
 	"orderform": "Orderform",
+	"email":     "Email",
 }
 
 // applyContactFieldModifiers creates and applies field modifiers from the event's new contact fields.

--- a/core/tasks/handler/worker_test.go
+++ b/core/tasks/handler/worker_test.go
@@ -468,8 +468,38 @@ func TestApplyContactFieldModifiers(t *testing.T) {
 		assert.Equal(t, assets.FieldTypeText, field.Type())
 	})
 
+	t.Run("email field is auto-created and applied", func(t *testing.T) {
+		require.Nil(t, oa.SessionAssets().Fields().Get("email"), "email field should not exist yet")
+
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"email": "test@example.com"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, oa, event, flowContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'email' AND is_active = TRUE AND value_type = 'T'`,
+			testdata.Org1.ID,
+		).Returns(1)
+
+		refreshedOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshFields)
+		require.NoError(t, err)
+		field := refreshedOA.FieldByKey("email")
+		require.NotNil(t, field)
+		assert.Equal(t, "Email", field.Name())
+		assert.Equal(t, assets.FieldTypeText, field.Type())
+	})
+
 	t.Run("both whitelisted fields in one event", func(t *testing.T) {
-		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform')`, testdata.Org1.ID)
+		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email')`, testdata.Org1.ID)
 		models.FlushCache()
 
 		freshOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshAll)
@@ -482,7 +512,7 @@ func TestApplyContactFieldModifiers(t *testing.T) {
 			OrgID:            testdata.Org1.ID,
 			MsgID:            msg.ID(),
 			MsgUUID:          flows.MsgUUID(uuids.New()),
-			NewContactFields: map[string]string{"segment": "vip", "orderform": "order-456"},
+			NewContactFields: map[string]string{"segment": "vip", "orderform": "order-456", "email": "cathy@example.com"},
 		}
 
 		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, freshOA, event, freshContact, models.NilTopupID)
@@ -492,13 +522,13 @@ func TestApplyContactFieldModifiers(t *testing.T) {
 		assert.True(t, recalcGroups)
 
 		testsuite.AssertQuery(t, db,
-			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform') AND is_active = TRUE`,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email') AND is_active = TRUE`,
 			testdata.Org1.ID,
-		).Returns(2)
+		).Returns(3)
 	})
 
 	t.Run("mix of existing, whitelisted, and unknown fields", func(t *testing.T) {
-		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform')`, testdata.Org1.ID)
+		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email')`, testdata.Org1.ID)
 		models.FlushCache()
 
 		freshOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshAll)


### PR DESCRIPTION
- Implemented auto-creation of the email field in the GetOrCreateContactField function.
- Updated tests to verify the creation and application of the email field in contact field modifiers.
- Adjusted database queries to include the email field in relevant assertions and deletions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small whitelist expansion to auto-create a new text field key (`email`) plus test updates; behavior remains gated to known keys and uses existing `GetOrCreateContactField` path.
> 
> **Overview**
> Incoming `MsgEvent.NewContactFields` can now auto-create and apply an `email` contact field (added to the `autoCreateFieldKeys` whitelist) when the org doesn’t already have it.
> 
> Tests are extended to cover `email` creation via `GetOrCreateContactField` and via `applyContactFieldModifiers`, and existing multi-field assertions/deletions are updated to include `email`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591c0042bcd14ac744f91a32a4ece92480727b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->