### PR TITLE
feat: add Zendesk Marketplace and OAuth configuration support

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.86.0
+----------
+* feat: add Zendesk Marketplace and OAuth configuration support
+
 1.85.2
 ----------
 * feat: check if is ab2(is_multi_agents) before publish sqs ticket event

--- a/core/models/assets.go
+++ b/core/models/assets.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nyaruka/mailroom/core/goflow"
 	"github.com/nyaruka/mailroom/runtime"
 	cache "github.com/patrickmn/go-cache"
+	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 )
 
@@ -516,6 +517,14 @@ func GetOrgAssetsWithRefresh(ctx context.Context, rt *runtime.Runtime, orgID Org
 }
 
 func (a *OrgAssets) OrgID() OrgID { return a.orgID }
+
+// DB returns the primary database pool associated with these assets, or nil if unavailable.
+func (a *OrgAssets) DB() *sqlx.DB {
+	if a == nil || a.rt == nil {
+		return nil
+	}
+	return a.rt.DB
+}
 
 func (a *OrgAssets) Env() envs.Environment { return a.org }
 

--- a/core/models/tickets.go
+++ b/core/models/tickets.go
@@ -65,7 +65,14 @@ func init() {
 
 func ticketServiceFactory(c *runtime.Config) engine.TicketServiceFactory {
 	return func(session flows.Session, ticketer *flows.Ticketer) (flows.TicketService, error) {
-		return ticketer.Asset().(*Ticketer).AsService(c, ticketer)
+		modelTicketer := ticketer.Asset().(*Ticketer)
+		var db Queryer
+		if oa, ok := session.Assets().Source().(*OrgAssets); ok {
+			if rtDB := oa.DB(); rtDB != nil {
+				db = rtDB
+			}
+		}
+		return modelTicketer.AsService(c, ticketer, context.Background(), db)
 	}
 }
 
@@ -159,7 +166,7 @@ func (t *Ticket) ForwardIncoming(ctx context.Context, rt *runtime.Runtime, org *
 		return errors.Errorf("can't find ticketer with id %d", t.t.TicketerID)
 	}
 
-	service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer))
+	service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer), ctx, rt.DB)
 	if err != nil {
 		return err
 	}
@@ -547,7 +554,7 @@ func CloseTickets(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, userI
 		for ticketerID, ticketerTickets := range byTicketer {
 			ticketer := oa.TicketerByID(ticketerID)
 			if ticketer != nil {
-				service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer))
+				service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer), ctx, rt.DB)
 				if err != nil {
 					return nil, err
 				}
@@ -619,7 +626,7 @@ func ReopenTickets(ctx context.Context, rt *runtime.Runtime, oa *OrgAssets, user
 		for ticketerID, ticketerTickets := range byTicketer {
 			ticketer := oa.TicketerByID(ticketerID)
 			if ticketer != nil {
-				service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer))
+				service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer), ctx, rt.DB)
 				if err != nil {
 					return nil, err
 				}
@@ -703,18 +710,43 @@ func (t *Ticketer) Type() string { return t.t.Type }
 // Config returns the named config value
 func (t *Ticketer) Config(key string) string { return t.t.Config[key] }
 
+// ConfigMap returns the ticketer configuration map (same backing store as Config / UpdateConfig).
+func (t *Ticketer) ConfigMap() map[string]string {
+	return t.t.Config
+}
+
+// BuildTicketer returns a ticketer without loading from the database (e.g. for tests or local assembly).
+func BuildTicketer(id TicketerID, uuid assets.TicketerUUID, orgID OrgID, ticketerType, name string, config map[string]string) *Ticketer {
+	cfg := make(map[string]string, len(config))
+	for k, v := range config {
+		cfg[k] = v
+	}
+	t := &Ticketer{}
+	t.t.ID = id
+	t.t.UUID = uuid
+	t.t.OrgID = orgID
+	t.t.Type = ticketerType
+	t.t.Name = name
+	t.t.Config = cfg
+	return t
+}
+
 // Reference returns an asset reference to this ticketer
 func (t *Ticketer) Reference() *assets.TicketerReference {
 	return assets.NewTicketerReference(t.t.UUID, t.t.Name)
 }
 
 // AsService builds the corresponding engine service for the passed in Ticketer
-func (t *Ticketer) AsService(cfg *runtime.Config, ticketer *flows.Ticketer) (TicketService, error) {
+func (t *Ticketer) AsService(cfg *runtime.Config, ticketer *flows.Ticketer, ctx context.Context, db Queryer) (TicketService, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	httpClient, httpRetries, _ := goflow.HTTP(cfg)
 
 	initFunc := ticketServices[t.Type()]
 	if initFunc != nil {
-		return initFunc(cfg, httpClient, httpRetries, ticketer, t.t.Config)
+		return initFunc(cfg, httpClient, httpRetries, ticketer, t, ctx, db)
 	}
 
 	return nil, errors.Errorf("unrecognized ticket service type '%s'", t.Type())
@@ -749,7 +781,7 @@ type TicketService interface {
 }
 
 // TicketServiceFunc is a func which creates a ticket service
-type TicketServiceFunc func(*runtime.Config, *http.Client, *httpx.RetryConfig, *flows.Ticketer, map[string]string) (TicketService, error)
+type TicketServiceFunc func(*runtime.Config, *http.Client, *httpx.RetryConfig, *flows.Ticketer, *Ticketer, context.Context, Queryer) (TicketService, error)
 
 var ticketServices = map[string]TicketServiceFunc{}
 

--- a/core/tasks/tickets/send_ticket_history.go
+++ b/core/tasks/tickets/send_ticket_history.go
@@ -104,7 +104,7 @@ func SendTicketHistory(ctx context.Context, rt *runtime.Runtime, task *SendHisto
 	}
 
 	// Create the service
-	service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer))
+	service, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer), ctx, rt.DB)
 	if err != nil {
 		return errors.Wrapf(err, "error creating ticketer service")
 	}

--- a/core/tasks/tickets/send_ticket_history_test.go
+++ b/core/tasks/tickets/send_ticket_history_test.go
@@ -1,6 +1,7 @@
 package tickets_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -131,7 +132,7 @@ func TestSendTicketHistoryRetry(t *testing.T) {
 }
 
 func setupMockTicketer(t *testing.T, db *sqlx.DB) *testdata.Ticketer {
-	models.RegisterTicketService("mock", func(cfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+	models.RegisterTicketService("mock", func(cfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
 		return &mockTicketService{}, nil
 	})
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -60,6 +60,12 @@ type Config struct {
 	S3MediaBucket        string `help:"the S3 bucket we will write attachments to"`
 	S3MediaPrefix        string `help:"the prefix that will be added to attachment filenames"`
 	S3MediaPrefixZendesk string `help:"the prefix that will be added to file attachment names for Zendesk tickets"`
+
+	ZendeskMarketplaceName   string `help:"the app name for Zendesk Marketplace API headers"`
+	ZendeskMarketplaceOrgID  string `help:"the organization ID for Zendesk Marketplace API headers"`
+	ZendeskMarketplaceAppID  string `help:"the app ID for Zendesk Marketplace API headers"`
+	ZendeskClientID          string `help:"the OAuth client ID for Zendesk Global OAuth"`
+	ZendeskClientSecret      string `help:"the OAuth client secret for Zendesk Global OAuth"`
 	S3SessionBucket      string `help:"the S3 bucket we will write attachments to"`
 	S3SessionPrefix      string `help:"the prefix that will be added to attachment filenames"`
 	S3DisableSSL         bool   `help:"whether we disable SSL when accessing S3. Should always be set to False unless you're hosting an S3 compatible service within a secure internal network"`

--- a/services/tickets/freshchat/service.go
+++ b/services/tickets/freshchat/service.go
@@ -1,6 +1,7 @@
 package freshchat
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -32,7 +33,8 @@ type service struct {
 	redactor   utils.Redactor
 }
 
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	baseURL := config["freshchat_domain"]
 	authToken := config["oauth_token"]
 	if baseURL == "" || authToken == "" {

--- a/services/tickets/freshchat/service_test.go
+++ b/services/tickets/freshchat/service_test.go
@@ -1,6 +1,7 @@
 package freshchat_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -26,15 +27,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+
+var freshEmptyRT = &runtime.Runtime{Config: &runtime.Config{}}
+
+func mustFreshSvc(rt *runtime.Runtime, ft *flows.Ticketer, cfg map[string]string) (models.TicketService, error) {
+	model := models.BuildTicketer(models.TicketerID(0), ft.UUID(), testdata.Org1.ID, "freshchat", "Freshchat", cfg)
+	return freshchat.NewService(rt.Config, http.DefaultClient, nil, ft, model, context.Background(), nil)
+}
+
 func TestNewService(t *testing.T) {
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "freshchat"))
 
 	// Test missing freshchat_domain
-	_, err := freshchat.NewService(
-		&runtime.Config{},
-		http.DefaultClient,
-		nil,
-		ticketer,
+	_, err := mustFreshSvc(freshEmptyRT, ticketer,
 		map[string]string{
 			"oauth_token": apiKey,
 		},
@@ -42,11 +47,7 @@ func TestNewService(t *testing.T) {
 	assert.EqualError(t, err, "missing freshchat_domain or oauth_token in freshchat config")
 
 	// Test missing oauth_token
-	_, err = freshchat.NewService(
-		&runtime.Config{},
-		http.DefaultClient,
-		nil,
-		ticketer,
+	_, err = mustFreshSvc(freshEmptyRT, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 		},
@@ -54,11 +55,7 @@ func TestNewService(t *testing.T) {
 	assert.EqualError(t, err, "missing freshchat_domain or oauth_token in freshchat config")
 
 	// Test valid config
-	svc, err := freshchat.NewService(
-		&runtime.Config{},
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFreshSvc(freshEmptyRT, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 			"oauth_token":      apiKey,
@@ -179,11 +176,7 @@ func TestOpen(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "freshchat"))
 
-	svc, err := freshchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFreshSvc(rt, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 			"oauth_token":      apiKey,
@@ -280,11 +273,7 @@ func TestOpenWithChannelID(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "freshchat"))
 
-	svc, err := freshchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFreshSvc(rt, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 			"oauth_token":      apiKey,
@@ -371,11 +360,7 @@ func TestOpenWithoutChannelID(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "freshchat"))
 
-	svc, err := freshchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFreshSvc(rt, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 			"oauth_token":      apiKey,
@@ -510,11 +495,7 @@ func TestForward(t *testing.T) {
 	}))
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "freshchat"))
-	svc, err := freshchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFreshSvc(rt, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 			"oauth_token":      apiKey,
@@ -583,11 +564,7 @@ func TestClose(t *testing.T) {
 	}))
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "freshchat"))
-	svc, err := freshchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFreshSvc(rt, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 			"oauth_token":      apiKey,
@@ -648,11 +625,7 @@ func TestReopen(t *testing.T) {
 	}))
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "freshchat"))
-	svc, err := freshchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFreshSvc(rt, ticketer,
 		map[string]string{
 			"freshchat_domain": baseURL,
 			"oauth_token":      apiKey,

--- a/services/tickets/intern/service.go
+++ b/services/tickets/intern/service.go
@@ -1,6 +1,7 @@
 package intern
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -25,7 +26,7 @@ type service struct {
 }
 
 // NewService creates a new internal ticket service
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
 	return &service{ticketer: ticketer}, nil
 }
 

--- a/services/tickets/intern/service_test.go
+++ b/services/tickets/intern/service_test.go
@@ -1,6 +1,7 @@
 package intern_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -32,13 +33,9 @@ func TestOpenAndForward(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "internal"))
 
-	svc, err := intern.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
-		nil,
-	)
+	model := models.BuildTicketer(models.TicketerID(0), ticketer.UUID(), testdata.Org1.ID, "internal", "Support", nil)
+	svc, err := intern.NewService(rt.Config, http.DefaultClient, nil, ticketer, model, ctx, nil)
+
 	require.NoError(t, err)
 
 	logger := &flows.HTTPLogger{}
@@ -80,7 +77,8 @@ func TestCloseAndReopen(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "internal"))
-	svc, err := intern.NewService(rt.Config, http.DefaultClient, nil, ticketer, nil)
+	model := models.BuildTicketer(models.TicketerID(0), ticketer.UUID(), testdata.Org1.ID, "internal", "Support", nil)
+	svc, err := intern.NewService(rt.Config, http.DefaultClient, nil, ticketer, model, context.Background(), nil)
 	require.NoError(t, err)
 
 	logger := &flows.HTTPLogger{}

--- a/services/tickets/mailgun/service.go
+++ b/services/tickets/mailgun/service.go
@@ -1,6 +1,7 @@
 package mailgun
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -85,7 +86,8 @@ type service struct {
 }
 
 // NewService creates a new mailgun email-based ticket service
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	domain := config[configDomain]
 	apiKey := config[configAPIKey]
 	toAddress := config[configToAddress]

--- a/services/tickets/mailgun/service_test.go
+++ b/services/tickets/mailgun/service_test.go
@@ -1,6 +1,7 @@
 package mailgun_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets/mailgun"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -23,6 +25,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+
+
+func mustMailgunSvc(rt *runtime.Runtime, ft *flows.Ticketer, cfg map[string]string) (models.TicketService, error) {
+	model := models.BuildTicketer(models.TicketerID(0), ft.UUID(), testdata.Org1.ID, "mailgun", "Support", cfg)
+	return mailgun.NewService(rt.Config, http.DefaultClient, nil, ft, model, context.Background(), nil)
+}
 
 func TestOpenAndForward(t *testing.T) {
 	ctx, rt, _, _ := testsuite.Get()
@@ -55,20 +64,12 @@ func TestOpenAndForward(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "mailgun"))
 
-	_, err = mailgun.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	_, err = mustMailgunSvc(rt, ticketer,
 		map[string]string{},
 	)
 	assert.EqualError(t, err, "missing domain or api_key or to_address or url_base in mailgun config")
 
-	svc, err := mailgun.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustMailgunSvc(rt, ticketer,
 		map[string]string{
 			"domain":     "tickets.rapidpro.io",
 			"api_key":    "123456789",
@@ -145,11 +146,7 @@ func TestCloseAndReopen(t *testing.T) {
 	}))
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "mailgun"))
-	svc, err := mailgun.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustMailgunSvc(rt, ticketer,
 		map[string]string{
 			"domain":     "tickets.rapidpro.io",
 			"api_key":    "123456789",

--- a/services/tickets/rocketchat/service.go
+++ b/services/tickets/rocketchat/service.go
@@ -1,6 +1,7 @@
 package rocketchat
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -37,7 +38,8 @@ type service struct {
 }
 
 // NewService creates a new RocketChat ticket service
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	baseURL := config[configBaseURL]
 	secret := config[configSecret]
 

--- a/services/tickets/rocketchat/service_test.go
+++ b/services/tickets/rocketchat/service_test.go
@@ -1,6 +1,7 @@
 package rocketchat_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets/rocketchat"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -23,6 +25,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+
+
+func mustRcSvc(rt *runtime.Runtime, ft *flows.Ticketer, cfg map[string]string) (models.TicketService, error) {
+	model := models.BuildTicketer(models.TicketerID(0), ft.UUID(), testdata.Org1.ID, "rocketchat", "Support", cfg)
+	return rocketchat.NewService(rt.Config, http.DefaultClient, nil, ft, model, context.Background(), nil)
+}
 
 func TestOpenAndForward(t *testing.T) {
 	ctx, rt, _, _ := testsuite.Get()
@@ -50,20 +59,12 @@ func TestOpenAndForward(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "rocketchat"))
 
-	_, err = rocketchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	_, err = mustRcSvc(rt, ticketer,
 		map[string]string{},
 	)
 	assert.EqualError(t, err, "missing base_url or secret config")
 
-	svc, err := rocketchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustRcSvc(rt, ticketer,
 		map[string]string{
 			"base_url": baseURL,
 			"secret":   secret,
@@ -125,11 +126,7 @@ func TestCloseAndReopen(t *testing.T) {
 	}))
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "rocketchat"))
-	svc, err := rocketchat.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustRcSvc(rt, ticketer,
 		map[string]string{
 			"base_url": baseURL,
 			"secret":   secret,

--- a/services/tickets/twilioflex/service.go
+++ b/services/tickets/twilioflex/service.go
@@ -67,7 +67,8 @@ type service struct {
 }
 
 // newService creates a new twilio flex ticket service
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	authToken := config[configurationAuthToken]
 	accountSid := config[configurationAccountSid]
 	chatServiceSid := config[configurationChatServiceSid]

--- a/services/tickets/twilioflex/service_test.go
+++ b/services/tickets/twilioflex/service_test.go
@@ -1,6 +1,7 @@
 package twilioflex_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets/twilioflex"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -25,6 +27,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+
+
+func mustFlexSvc(rt *runtime.Runtime, ft *flows.Ticketer, cfg map[string]string) (models.TicketService, error) {
+	model := models.BuildTicketer(models.TicketerID(0), ft.UUID(), testdata.Org1.ID, "twilioflex", "Support", cfg)
+	return twilioflex.NewService(rt.Config, http.DefaultClient, nil, ft, model, context.Background(), nil)
+}
 
 func TestOpenAndForward(t *testing.T) {
 	ctx, rt, _, _ := testsuite.Get()
@@ -390,20 +399,12 @@ func TestOpenAndForward(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "twilioflex"))
 
-	_, err = twilioflex.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	_, err = mustFlexSvc(rt, ticketer,
 		map[string]string{},
 	)
 	assert.EqualError(t, err, "missing auth_token or account_sid or chat_service_sid or workspace_sid in twilio flex config")
 
-	svc, err := twilioflex.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFlexSvc(rt, ticketer,
 		map[string]string{
 			"auth_token":       authToken,
 			"account_sid":      accountSid,
@@ -570,11 +571,7 @@ func TestCloseAndReopen(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "twilioflex"))
 
-	svc, err := twilioflex.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustFlexSvc(rt, ticketer,
 		map[string]string{
 			"auth_token":       authToken,
 			"account_sid":      accountSid,

--- a/services/tickets/twilioflex2/service.go
+++ b/services/tickets/twilioflex2/service.go
@@ -71,7 +71,8 @@ type service struct {
 	conversationServiceSid string
 }
 
-func NewService(rtConfig *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtConfig *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	authToken := config[configurationAuthToken]
 	accountSid := config[configurationAccountSid]
 	instanceSid := config[configurationInstanceSid]

--- a/services/tickets/twilioflex2/service_test.go
+++ b/services/tickets/twilioflex2/service_test.go
@@ -1,6 +1,7 @@
 package twilioflex2_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets/twilioflex2"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -36,6 +38,11 @@ const (
 	testConversationServiceSid = "CS12345678901234567890123456789012"
 )
 
+func mustFlex2Svc(rt *runtime.Runtime, ticketer *flows.Ticketer, cfg map[string]string) (models.TicketService, error) {
+	model := models.BuildTicketer(models.TicketerID(0), ticketer.UUID(), testdata.Org1.ID, "twilioflex2", "TwilioFlex2", cfg)
+	return twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, model, context.Background(), nil)
+}
+
 func TestNewService(t *testing.T) {
 	_, rt, _, _ := testsuite.Get()
 	defer testsuite.Reset(testsuite.ResetAll)
@@ -51,7 +58,7 @@ func TestNewService(t *testing.T) {
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "TwilioFlex2", "twilioflex2"))
 
 	// Test with empty configuration - should return error
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{})
+	svc, err := mustFlex2Svc(rt, ticketer, map[string]string{})
 	assert.Error(t, err)
 	assert.Nil(t, svc)
 	assert.Contains(t, err.Error(), "missing auth_token or account_sid")
@@ -63,7 +70,7 @@ func TestNewService(t *testing.T) {
 		// missing other required fields
 	}
 
-	svc, err = twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, incompleteConfig)
+	svc, err = mustFlex2Svc(rt, ticketer, incompleteConfig)
 	assert.Error(t, err)
 	assert.Nil(t, svc)
 	assert.Contains(t, err.Error(), "missing auth_token or account_sid")
@@ -100,7 +107,7 @@ func TestOpen(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	interactionWebhookUrl := fmt.Sprintf("https://flex-api.twilio.com/v1/Instances/%s/InteractionWebhooks", testInstanceSid)
@@ -198,7 +205,7 @@ func TestOpenWithMissingConversationSid(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	interactionWebhookUrl := fmt.Sprintf("https://flex-api.twilio.com/v1/Instances/%s/InteractionWebhooks", testInstanceSid)
@@ -274,7 +281,7 @@ func TestForward(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	// Create a test ticket
@@ -344,7 +351,7 @@ func TestForwardWithAttachments(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	// Create a test ticket
@@ -439,7 +446,7 @@ func TestSendHistory(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	// Create test data
@@ -534,7 +541,7 @@ func TestSendHistoryWithHistoryAfter(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	// Create test data with history_after in ticket body
@@ -619,7 +626,7 @@ func TestSendHistoryWithAttachments(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	// Test data
@@ -769,7 +776,7 @@ func TestClose(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	logger := &flows.HTTPLogger{}
@@ -800,7 +807,7 @@ func TestReopen(t *testing.T) {
 		"conversation_service_sid": testConversationServiceSid,
 	}
 
-	svc, err := twilioflex2.NewService(rt.Config, http.DefaultClient, nil, ticketer, config)
+	svc, err := mustFlex2Svc(rt, ticketer, config)
 	require.NoError(t, err)
 
 	logger := &flows.HTTPLogger{}

--- a/services/tickets/utils.go
+++ b/services/tickets/utils.go
@@ -55,7 +55,7 @@ func FromTicketUUID(ctx context.Context, rt *runtime.Runtime, uuid flows.TicketU
 	}
 
 	// and load it as a service
-	svc, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer))
+	svc, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer), ctx, rt.DB)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error loading ticketer service")
 	}
@@ -71,7 +71,7 @@ func FromTicketerUUID(ctx context.Context, rt *runtime.Runtime, uuid assets.Tick
 	}
 
 	// and load it as a service
-	svc, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer))
+	svc, err := ticketer.AsService(rt.Config, flows.NewTicketer(ticketer), ctx, rt.DB)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error loading ticketer service")
 	}

--- a/services/tickets/wenichats/service.go
+++ b/services/tickets/wenichats/service.go
@@ -119,7 +119,8 @@ type service struct {
 	sectorUUID string
 }
 
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	sectorUUID := config[configurationSectorUUID]
 	baseURL := rtCfg.WenichatsServiceURL
 	if sectorUUID == "" {

--- a/services/tickets/wenichats/service_test.go
+++ b/services/tickets/wenichats/service_test.go
@@ -1,6 +1,7 @@
 package wenichats_test
 
 import (
+	"context"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -20,6 +21,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets/wenichats"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -27,6 +29,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+
+
+func mustWeniSvc(rt *runtime.Runtime, ft *flows.Ticketer, cfg map[string]string) (models.TicketService, error) {
+	model := models.BuildTicketer(models.TicketerID(0), ft.UUID(), testdata.Org1.ID, "wenichats", "Wenichats", cfg)
+	return wenichats.NewService(rt.Config, http.DefaultClient, nil, ft, model, context.Background(), nil)
+}
 
 func TestOpenAndForward(t *testing.T) {
 	ctx, rt, _, _ := testsuite.Get()
@@ -473,11 +482,7 @@ func TestOpenAndForward(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "wenichats"))
 
-	_, err = wenichats.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	_, err = mustWeniSvc(rt, ticketer,
 		map[string]string{},
 	)
 	assert.EqualError(t, err, "missing project_auth or sector_uuid")
@@ -492,11 +497,7 @@ func TestOpenAndForward(t *testing.T) {
 
 	wenichats.SetDB(sqlxDB)
 
-	svc, err := wenichats.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustWeniSvc(rt, ticketer,
 		map[string]string{
 			"project_auth": authToken,
 			"sector_uuid":  "1a4bae05-993c-4f3b-91b5-80f4e09951f2",
@@ -806,11 +807,7 @@ func TestOpenFails(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "wenichats"))
 
-	svc, err := wenichats.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustWeniSvc(rt, ticketer,
 		map[string]string{
 			"project_auth": authToken,
 			"sector_uuid":  "1a4bae05-993c-4f3b-91b5-80f4e09951f2",
@@ -936,11 +933,7 @@ func TestCloseAndReopen(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "wenichats"))
 
-	svc, err := wenichats.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustWeniSvc(rt, ticketer,
 		map[string]string{
 			"project_auth": authToken,
 			"sector_uuid":  "1a4bae05-993c-4f3b-91b5-80f4e09951f2",
@@ -991,11 +984,7 @@ func TestSendHistory(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "wenichats"))
 
-	svc, err := wenichats.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustWeniSvc(rt, ticketer,
 		map[string]string{
 			"project_auth": authToken,
 			"sector_uuid":  "1a4bae05-993c-4f3b-91b5-80f4e09951f2",
@@ -1082,11 +1071,7 @@ func TestDefaultSendHistory(t *testing.T) {
 
 	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "wenichats"))
 
-	svc, err := wenichats.NewService(
-		rt.Config,
-		http.DefaultClient,
-		nil,
-		ticketer,
+	svc, err := mustWeniSvc(rt, ticketer,
 		map[string]string{
 			"project_auth": authToken,
 			"sector_uuid":  "1a4bae05-993c-4f3b-91b5-80f4e09951f2",

--- a/services/tickets/zendesk/client.go
+++ b/services/tickets/zendesk/client.go
@@ -13,20 +13,98 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 )
 
+// MarketplaceConfig holds the Zendesk Marketplace identification headers
+// required for all API requests from public apps.
+type MarketplaceConfig struct {
+	Name  string
+	OrgID string
+	AppID string
+}
+
+// OAuthConfig holds the credentials needed to refresh expired OAuth tokens.
+type OAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	RefreshToken string
+	OnRefresh    func(newAccessToken, newRefreshToken string)
+}
+
 type baseClient struct {
 	httpClient  *http.Client
 	httpRetries *httpx.RetryConfig
 	subdomain   string
 	token       string
+	marketplace *MarketplaceConfig
+	oauth       *OAuthConfig
 }
 
-func newBaseClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, subdomain, token string) baseClient {
+func newBaseClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, subdomain, token string, marketplace *MarketplaceConfig, oauth *OAuthConfig) baseClient {
 	return baseClient{
 		httpClient:  httpClient,
 		httpRetries: httpRetries,
 		subdomain:   subdomain,
 		token:       token,
+		marketplace: marketplace,
+		oauth:       oauth,
 	}
+}
+
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+}
+
+func (c *baseClient) refreshAccessToken() error {
+	if c.oauth == nil || c.oauth.RefreshToken == "" {
+		return errors.New("no refresh token available")
+	}
+
+	payload := map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": c.oauth.RefreshToken,
+		"client_id":     c.oauth.ClientID,
+		"client_secret": c.oauth.ClientSecret,
+		"scope":         "read write",
+	}
+
+	data, err := jsonx.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("https://%s.zendesk.com/oauth/tokens", c.subdomain)
+	req, err := httpx.NewRequest("POST", url, bytes.NewReader(data), map[string]string{
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return err
+	}
+
+	trace, err := httpx.DoTrace(c.httpClient, req, nil, nil, -1)
+	if err != nil {
+		return fmt.Errorf("token refresh request failed: %w", err)
+	}
+
+	if trace.Response.StatusCode != 200 {
+		return fmt.Errorf("token refresh returned status %d", trace.Response.StatusCode)
+	}
+
+	tokenResp := &oauthTokenResponse{}
+	if err := jsonx.Unmarshal(trace.ResponseBody, tokenResp); err != nil {
+		return fmt.Errorf("failed to parse token refresh response: %w", err)
+	}
+
+	c.token = tokenResp.AccessToken
+	if tokenResp.RefreshToken != "" {
+		c.oauth.RefreshToken = tokenResp.RefreshToken
+	}
+
+	if c.oauth.OnRefresh != nil {
+		c.oauth.OnRefresh(tokenResp.AccessToken, tokenResp.RefreshToken)
+	}
+
+	return nil
 }
 
 type errorResponse struct {
@@ -52,28 +130,53 @@ func (c *baseClient) delete(endpoint string) (*httpx.Trace, error) {
 
 func (c *baseClient) request(method, endpoint string, payload interface{}, response interface{}) (*httpx.Trace, error) {
 	url := fmt.Sprintf("https://%s.zendesk.com/api/v2/%s", c.subdomain, endpoint)
-	headers := map[string]string{
-		"Authorization": fmt.Sprintf("Bearer %s", c.token),
-	}
-	var body io.Reader
 
+	var payloadData []byte
 	if payload != nil {
 		data, err := jsonx.Marshal(payload)
 		if err != nil {
 			return nil, err
 		}
-		body = bytes.NewReader(data)
-		headers["Content-Type"] = "application/json"
+		payloadData = data
 	}
 
-	req, err := httpx.NewRequest(method, url, body, headers)
-	if err != nil {
-		return nil, err
+	makeRequest := func() (*httpx.Trace, error) {
+		headers := map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", c.token),
+		}
+
+		if c.marketplace != nil && c.marketplace.Name != "" {
+			headers["X-Zendesk-Marketplace-Name"] = c.marketplace.Name
+			headers["X-Zendesk-Marketplace-Organization-Id"] = c.marketplace.OrgID
+			headers["X-Zendesk-Marketplace-App-Id"] = c.marketplace.AppID
+		}
+
+		var body io.Reader
+		if payloadData != nil {
+			body = bytes.NewReader(payloadData)
+			headers["Content-Type"] = "application/json"
+		}
+
+		req, err := httpx.NewRequest(method, url, body, headers)
+		if err != nil {
+			return nil, err
+		}
+
+		return httpx.DoTrace(c.httpClient, req, c.httpRetries, nil, -1)
 	}
 
-	trace, err := httpx.DoTrace(c.httpClient, req, c.httpRetries, nil, -1)
+	trace, err := makeRequest()
 	if err != nil {
 		return trace, err
+	}
+
+	if trace.Response.StatusCode == 401 && c.oauth != nil && c.oauth.RefreshToken != "" {
+		if refreshErr := c.refreshAccessToken(); refreshErr == nil {
+			trace, err = makeRequest()
+			if err != nil {
+				return trace, err
+			}
+		}
 	}
 
 	if trace.Response.StatusCode >= 400 {
@@ -94,8 +197,8 @@ type RESTClient struct {
 }
 
 // NewRESTClient creates a new REST client
-func NewRESTClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, subdomain, token string) *RESTClient {
-	return &RESTClient{baseClient: newBaseClient(httpClient, httpRetries, subdomain, token)}
+func NewRESTClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, subdomain, token string, marketplace *MarketplaceConfig, oauth *OAuthConfig) *RESTClient {
+	return &RESTClient{baseClient: newBaseClient(httpClient, httpRetries, subdomain, token, marketplace, oauth)}
 }
 
 type Webhook struct {
@@ -229,8 +332,8 @@ type PushClient struct {
 }
 
 // NewPushClient creates a new push client
-func NewPushClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, subdomain, token string) *PushClient {
-	return &PushClient{baseClient: newBaseClient(httpClient, httpRetries, subdomain, token)}
+func NewPushClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, subdomain, token string, marketplace *MarketplaceConfig, oauth *OAuthConfig) *PushClient {
+	return &PushClient{baseClient: newBaseClient(httpClient, httpRetries, subdomain, token, marketplace, oauth)}
 }
 
 // FieldValue is a value for the named field

--- a/services/tickets/zendesk/client_test.go
+++ b/services/tickets/zendesk/client_test.go
@@ -43,7 +43,7 @@ func TestCreateWebhook(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789")
+	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789", nil, nil)
 	webhook := &zendesk.Webhook{
 		Authentication: struct {
 			AddPosition string "json:\"add_position\""
@@ -87,7 +87,7 @@ func TestDeleteWebhook(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789")
+	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789", nil, nil)
 
 	trace, err := client.DeleteWebhook(123)
 
@@ -125,7 +125,7 @@ func TestCreateTrigger(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789")
+	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789", nil, nil)
 	trigger := &zendesk.Trigger{
 		Title: "Temba",
 		Conditions: zendesk.Conditions{
@@ -161,7 +161,7 @@ func TestDeleteTrigger(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789")
+	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789", nil, nil)
 
 	trace, err := client.DeleteTrigger(123)
 
@@ -183,7 +183,7 @@ func TestUpdateManyTickets(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789")
+	client := zendesk.NewRESTClient(http.DefaultClient, nil, "nyaruka", "123456789", nil, nil)
 
 	jobStatus, trace, err := client.UpdateManyTickets([]int64{123, 234}, "solved")
 
@@ -215,7 +215,7 @@ func TestPush(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewPushClient(http.DefaultClient, nil, "nyaruka", "123456789")
+	client := zendesk.NewPushClient(http.DefaultClient, nil, "nyaruka", "123456789", nil, nil)
 
 	_, _, err := client.Push("1234-abcd", "5678-edfg", []*zendesk.ExternalResource{})
 	assert.EqualError(t, err, "unable to connect to server")
@@ -286,7 +286,7 @@ func TestCreateUser(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewRESTClient(http.DefaultClient, nil, "mocked_subdomain", "123456789")
+	client := zendesk.NewRESTClient(http.DefaultClient, nil, "mocked_subdomain", "123456789", nil, nil)
 
 	user := &zendesk.User{
 		Name:       "Dummy User",
@@ -321,7 +321,7 @@ func TestSearchUser(t *testing.T) {
 		},
 	}))
 
-	client := zendesk.NewRESTClient(http.DefaultClient, nil, "mocked_subdomain", "123456789")
+	client := zendesk.NewRESTClient(http.DefaultClient, nil, "mocked_subdomain", "123456789", nil, nil)
 
 	_, _, err := client.SearchUser(userUUID)
 	assert.EqualError(t, err, "unable to connect to server")

--- a/services/tickets/zendesk/service.go
+++ b/services/tickets/zendesk/service.go
@@ -1,6 +1,7 @@
 package zendesk
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	"github.com/nyaruka/null"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -55,7 +57,8 @@ type service struct {
 }
 
 // NewService creates a new zendesk ticket service
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	subdomain := config[configSubdomain]
 	secret := config[configSecret]
 	oAuthToken := config[configOAuthToken]
@@ -75,12 +78,28 @@ func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *htt
 		}
 
 		refreshToken := config[configRefreshToken]
+		persistCtx := ctx
+		if persistCtx == nil {
+			persistCtx = context.Background()
+		}
+
 		var oauth *OAuthConfig
 		if rtCfg.ZendeskClientID != "" && refreshToken != "" {
 			oauth = &OAuthConfig{
 				ClientID:     rtCfg.ZendeskClientID,
 				ClientSecret: rtCfg.ZendeskClientSecret,
 				RefreshToken: refreshToken,
+			}
+			if db != nil {
+				oauth.OnRefresh = func(newAccessToken, newRefreshToken string) {
+					updates := map[string]string{configOAuthToken: newAccessToken}
+					if newRefreshToken != "" {
+						updates[configRefreshToken] = newRefreshToken
+					}
+					if err := model.UpdateConfig(persistCtx, db, updates, nil); err != nil {
+						logrus.WithError(err).WithField("ticketer_uuid", model.UUID()).Error("failed to persist zendesk oauth tokens after refresh")
+					}
+				}
 			}
 		}
 

--- a/services/tickets/zendesk/service.go
+++ b/services/tickets/zendesk/service.go
@@ -24,13 +24,14 @@ import (
 const (
 	typeZendesk = "zendesk"
 
-	configSubdomain  = "subdomain"
-	configSecret     = "secret"
-	configOAuthToken = "oauth_token"
-	configPushID     = "push_id"
-	configPushToken  = "push_token"
-	configWebhookID  = "webhook_id"
-	configTriggerID  = "trigger_id"
+	configSubdomain    = "subdomain"
+	configSecret       = "secret"
+	configOAuthToken   = "oauth_token"
+	configRefreshToken = "refresh_token"
+	configPushID       = "push_id"
+	configPushToken    = "push_token"
+	configWebhookID    = "webhook_id"
+	configTriggerID    = "trigger_id"
 
 	statusOpen   = "open"
 	statusSolved = "solved"
@@ -64,10 +65,29 @@ func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *htt
 	triggerID := config[configTriggerID]
 
 	if subdomain != "" && secret != "" && oAuthToken != "" && instancePushID != "" && pushToken != "" {
+		var marketplace *MarketplaceConfig
+		if rtCfg.ZendeskMarketplaceName != "" {
+			marketplace = &MarketplaceConfig{
+				Name:  rtCfg.ZendeskMarketplaceName,
+				OrgID: rtCfg.ZendeskMarketplaceOrgID,
+				AppID: rtCfg.ZendeskMarketplaceAppID,
+			}
+		}
+
+		refreshToken := config[configRefreshToken]
+		var oauth *OAuthConfig
+		if rtCfg.ZendeskClientID != "" && refreshToken != "" {
+			oauth = &OAuthConfig{
+				ClientID:     rtCfg.ZendeskClientID,
+				ClientSecret: rtCfg.ZendeskClientSecret,
+				RefreshToken: refreshToken,
+			}
+		}
+
 		return &service{
 			rtConfig:       rtCfg,
-			restClient:     NewRESTClient(httpClient, httpRetries, subdomain, oAuthToken),
-			pushClient:     NewPushClient(httpClient, httpRetries, subdomain, pushToken),
+			restClient:     NewRESTClient(httpClient, httpRetries, subdomain, oAuthToken, marketplace, oauth),
+			pushClient:     NewPushClient(httpClient, httpRetries, subdomain, pushToken, marketplace, oauth),
 			ticketer:       ticketer,
 			redactor:       utils.NewRedactor(flows.RedactionMask, oAuthToken, pushToken),
 			secret:         secret,

--- a/services/tickets/zendesk/service_test.go
+++ b/services/tickets/zendesk/service_test.go
@@ -1,6 +1,7 @@
 package zendesk_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -85,14 +86,17 @@ func TestOpenAndForward(t *testing.T) {
 		},
 	}))
 
-	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "zendesk"))
+	tickUUID := assets.TicketerUUID(uuids.New())
+	flowTicketer := flows.NewTicketer(static.NewTicketer(tickUUID, "Support", "zendesk"))
 
 	_, err = zendesk.NewService(
 		rt.Config,
 		http.DefaultClient,
 		nil,
-		ticketer,
-		map[string]string{},
+		flowTicketer,
+		models.BuildTicketer(models.TicketerID(0), tickUUID, testdata.Org1.ID, "zendesk", "Support", map[string]string{}),
+		ctx,
+		nil,
 	)
 	assert.EqualError(t, err, "missing subdomain or secret or oauth_token or push_id or push_token in zendesk config")
 
@@ -100,14 +104,16 @@ func TestOpenAndForward(t *testing.T) {
 		rt.Config,
 		http.DefaultClient,
 		nil,
-		ticketer,
-		map[string]string{
+		flowTicketer,
+		models.BuildTicketer(models.TicketerID(0), tickUUID, testdata.Org1.ID, "zendesk", "Support", map[string]string{
 			"subdomain":   "nyaruka",
 			"secret":      "sesame",
 			"oauth_token": "987654321",
 			"push_id":     "1234-abcd",
 			"push_token":  "123456789",
-		},
+		}),
+		ctx,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -186,19 +192,23 @@ func TestCloseAndReopen(t *testing.T) {
 		},
 	}))
 
-	ticketer := flows.NewTicketer(static.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "zendesk"))
+	tickUUID := assets.TicketerUUID(uuids.New())
+	flowTicketer := flows.NewTicketer(static.NewTicketer(tickUUID, "Support", "zendesk"))
+	model := models.BuildTicketer(models.TicketerID(0), tickUUID, testdata.Org1.ID, "zendesk", "Support", map[string]string{
+		"subdomain":   "nyaruka",
+		"secret":      "sesame",
+		"oauth_token": "987654321",
+		"push_id":     "1234-abcd",
+		"push_token":  "123456789",
+	})
 	svc, err := zendesk.NewService(
 		rt.Config,
 		http.DefaultClient,
 		nil,
-		ticketer,
-		map[string]string{
-			"subdomain":   "nyaruka",
-			"secret":      "sesame",
-			"oauth_token": "987654321",
-			"push_id":     "1234-abcd",
-			"push_token":  "123456789",
-		},
+		flowTicketer,
+		model,
+		context.Background(),
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/web/ticket/open.go
+++ b/web/ticket/open.go
@@ -67,7 +67,7 @@ func handleOpen(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *mo
 
 	currentSession := newEndpointSession(contact, oa.Env())
 
-	svc, err := ticketer.AsService(rt.Config, flowsTicketer)
+	svc, err := ticketer.AsService(rt.Config, flowsTicketer, ctx, rt.DB)
 	if err != nil {
 		return nil, 500, errors.Wrapf(err, "error creating ticketer service")
 	}


### PR DESCRIPTION
- Updated ticket service constructors across various services to accept context and database parameters.
- Modified the `AsService` method in the `Ticketer` struct to include context and database queryer.
- Adjusted related tests to accommodate the new service initialization requirements.
- Added a new method `DB` in `OrgAssets` to retrieve the database connection.