### PR TITLE
feat: add session field support in contact field modifiers

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.87.0
+----------
+* feat: add session field support in contact field modifiers
+
 1.86.0
 ----------
 * feat: add POST /mr/ticket/change_ticketer endpoint to move tickets between ticketers without closing them

--- a/core/models/fields_test.go
+++ b/core/models/fields_test.go
@@ -104,6 +104,9 @@ func TestGetOrCreateContactField(t *testing.T) {
 		err = models.GetOrCreateContactField(ctx, db, orgID, "email", "Email")
 		require.NoError(t, err)
 
+		err = models.GetOrCreateContactField(ctx, db, orgID, "session", "Session")
+		require.NoError(t, err)
+
 		testsuite.AssertQuery(t, db,
 			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'orderform' AND is_active = TRUE`,
 			orgID,
@@ -114,11 +117,17 @@ func TestGetOrCreateContactField(t *testing.T) {
 			orgID,
 		).Returns(1)
 
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'session' AND is_active = TRUE`,
+			orgID,
+		).Returns(1)
+
 		oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, orgID, models.RefreshFields)
 		require.NoError(t, err)
 
 		assert.NotNil(t, oa.FieldByKey("segment"))
 		assert.NotNil(t, oa.FieldByKey("orderform"))
 		assert.NotNil(t, oa.FieldByKey("email"))
+		assert.NotNil(t, oa.FieldByKey("session"))
 	})
 }

--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -778,6 +778,7 @@ var autoCreateFieldKeys = map[string]string{
 	"segment":   "Segment",
 	"orderform": "Orderform",
 	"email":     "Email",
+	"session":   "Session",
 }
 
 // applyContactFieldModifiers creates and applies field modifiers from the event's new contact fields.

--- a/core/tasks/handler/worker_test.go
+++ b/core/tasks/handler/worker_test.go
@@ -498,8 +498,38 @@ func TestApplyContactFieldModifiers(t *testing.T) {
 		assert.Equal(t, assets.FieldTypeText, field.Type())
 	})
 
+	t.Run("session field is auto-created and applied", func(t *testing.T) {
+		require.Nil(t, oa.SessionAssets().Fields().Get("session"), "session field should not exist yet")
+
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"session": "abc123"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, oa, event, flowContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'session' AND is_active = TRUE AND value_type = 'T'`,
+			testdata.Org1.ID,
+		).Returns(1)
+
+		refreshedOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshFields)
+		require.NoError(t, err)
+		field := refreshedOA.FieldByKey("session")
+		require.NotNil(t, field)
+		assert.Equal(t, "Session", field.Name())
+		assert.Equal(t, assets.FieldTypeText, field.Type())
+	})
+
 	t.Run("both whitelisted fields in one event", func(t *testing.T) {
-		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email')`, testdata.Org1.ID)
+		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email', 'session')`, testdata.Org1.ID)
 		models.FlushCache()
 
 		freshOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshAll)
@@ -512,7 +542,7 @@ func TestApplyContactFieldModifiers(t *testing.T) {
 			OrgID:            testdata.Org1.ID,
 			MsgID:            msg.ID(),
 			MsgUUID:          flows.MsgUUID(uuids.New()),
-			NewContactFields: map[string]string{"segment": "vip", "orderform": "order-456", "email": "cathy@example.com"},
+			NewContactFields: map[string]string{"segment": "vip", "orderform": "order-456", "email": "cathy@example.com", "session": "sess-789"},
 		}
 
 		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, freshOA, event, freshContact, models.NilTopupID)
@@ -522,13 +552,13 @@ func TestApplyContactFieldModifiers(t *testing.T) {
 		assert.True(t, recalcGroups)
 
 		testsuite.AssertQuery(t, db,
-			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email') AND is_active = TRUE`,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email', 'session') AND is_active = TRUE`,
 			testdata.Org1.ID,
-		).Returns(3)
+		).Returns(4)
 	})
 
 	t.Run("mix of existing, whitelisted, and unknown fields", func(t *testing.T) {
-		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email')`, testdata.Org1.ID)
+		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email', 'session')`, testdata.Org1.ID)
 		models.FlushCache()
 
 		freshOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshAll)


### PR DESCRIPTION
- Implemented auto-creation of the session field in the GetOrCreateContactField function.
- Updated tests to verify the creation and application of the session field in contact field modifiers.
- Adjusted database queries to include the session field in relevant assertions and deletions.