### PR TITLE
Enhance WppBroadcastMessage to include DirectSendTemplateName

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.87.1
+----------
+* feat: enhance WppBroadcastMessage to include DirectSendTemplateName
+
 1.87.0
 ----------
 * feat: add session field support in contact field modifiers

--- a/core/models/msgs.go
+++ b/core/models/msgs.go
@@ -767,6 +767,9 @@ func newOutgoingMsgWpp(rt *runtime.Runtime, org *Org, channel *Channel, contactI
 		if msgWpp.DirectSend() {
 			metadata["direct_send"] = true
 		}
+		if msgWpp.DirectSendTemplateName() != "" {
+			metadata["direct_send_template_name"] = msgWpp.DirectSendTemplateName()
+		}
 		if msgWpp.TTLSeconds() != 0 {
 			metadata["ttl_seconds"] = msgWpp.TTLSeconds()
 		}
@@ -1669,24 +1672,25 @@ type BroadcastCatalogMessage struct {
 }
 
 type WppBroadcastMessage struct {
-	Text             string                    `json:"text,omitempty"`
-	Header           BroadcastMessageHeader    `json:"header,omitempty"`
-	Footer           string                    `json:"footer,omitempty"`
-	Attachments      []utils.Attachment        `json:"attachments,omitempty"`
-	QuickReplies     []string                  `json:"quick_replies,omitempty"`
-	Template         WppBroadcastTemplate      `json:"template,omitempty"`
-	InteractionType  string                    `json:"interaction_type,omitempty"`
-	OrderDetails     flows.OrderDetailsMessage `json:"order_details,omitempty"`
-	FlowMessage      flows.FlowMessage         `json:"flow_message,omitempty"`
-	ListMessage      flows.ListMessage         `json:"list_message,omitempty"`
-	CTAMessage       flows.CTAMessage          `json:"cta_message,omitempty"`
-	CarouselMessage  []flows.CarouselMessage   `json:"carousel,omitempty"`
-	Buttons          []flows.ButtonComponent   `json:"buttons,omitempty"`
-	CatalogMessage   BroadcastCatalogMessage   `json:"catalog_message,omitempty"`
-	ActionExternalID string                    `json:"action_external_id,omitempty"`
-	ActionType       string                    `json:"action_type,omitempty"`
-	DirectSend       bool                      `json:"direct_send,omitempty"`
-	TTLSeconds       int                       `json:"ttl_seconds,omitempty"`
+	Text                   string                    `json:"text,omitempty"`
+	Header                 BroadcastMessageHeader    `json:"header,omitempty"`
+	Footer                 string                    `json:"footer,omitempty"`
+	Attachments            []utils.Attachment        `json:"attachments,omitempty"`
+	QuickReplies           []string                  `json:"quick_replies,omitempty"`
+	Template               WppBroadcastTemplate      `json:"template,omitempty"`
+	InteractionType        string                    `json:"interaction_type,omitempty"`
+	OrderDetails           flows.OrderDetailsMessage `json:"order_details,omitempty"`
+	FlowMessage            flows.FlowMessage         `json:"flow_message,omitempty"`
+	ListMessage            flows.ListMessage         `json:"list_message,omitempty"`
+	CTAMessage             flows.CTAMessage          `json:"cta_message,omitempty"`
+	CarouselMessage        []flows.CarouselMessage   `json:"carousel,omitempty"`
+	Buttons                []flows.ButtonComponent   `json:"buttons,omitempty"`
+	CatalogMessage         BroadcastCatalogMessage   `json:"catalog_message,omitempty"`
+	ActionExternalID       string                    `json:"action_external_id,omitempty"`
+	ActionType             string                    `json:"action_type,omitempty"`
+	DirectSend             bool                      `json:"direct_send,omitempty"`
+	DirectSendTemplateName string                    `json:"direct_send_template_name,omitempty"`
+	TTLSeconds             int                       `json:"ttl_seconds,omitempty"`
 }
 
 type WppBroadcast struct {
@@ -1871,6 +1875,7 @@ func CreateWppBroadcastMessages(ctx context.Context, rt *runtime.Runtime, oa *Or
 		templateCarousel := make([]flows.CarouselCard, len(bcast.Msg().Template.Carousel))
 		copy(templateCarousel, bcast.Msg().Template.Carousel)
 		directSend := bcast.Msg().DirectSend
+		directSendTemplateName := bcast.Msg().DirectSendTemplateName
 		ttlSeconds := bcast.Msg().TTLSeconds
 
 		ctaMessage := bcast.Msg().CTAMessage
@@ -2050,6 +2055,7 @@ func CreateWppBroadcastMessages(ctx context.Context, rt *runtime.Runtime, oa *Or
 			carouselMessage,
 			directSend,
 			ttlSeconds,
+			directSendTemplateName,
 		)
 
 		extraMetadata := map[string]interface{}{}

--- a/go.mod
+++ b/go.mod
@@ -95,4 +95,4 @@ go 1.23
 
 replace github.com/nyaruka/gocommon => github.com/Ilhasoft/gocommon v1.16.2-weni
 
-replace github.com/nyaruka/goflow => github.com/weni-ai/goflow v1.20.3-a1-staging
+replace github.com/nyaruka/goflow => github.com/weni-ai/goflow v1.20.3

--- a/go.mod
+++ b/go.mod
@@ -95,4 +95,4 @@ go 1.23
 
 replace github.com/nyaruka/gocommon => github.com/Ilhasoft/gocommon v1.16.2-weni
 
-replace github.com/nyaruka/goflow => github.com/weni-ai/goflow v1.20.2
+replace github.com/nyaruka/goflow => github.com/weni-ai/goflow v1.20.3-a1-staging

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,8 @@ github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLD
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
-github.com/weni-ai/goflow v1.20.2 h1:LzZnKNahAI1gt907p58LbeFc4hma4MYPV/6B8WVgx78=
-github.com/weni-ai/goflow v1.20.2/go.mod h1:JdwQA06TLpen2PL4m8Cm0fO7ovfvr1NH9w3vQU6J58M=
+github.com/weni-ai/goflow v1.20.3-a1-staging h1:dlucZ1r1a0q2vqlU4pwa/UAuPFaARXCBu9r9fwBE990=
+github.com/weni-ai/goflow v1.20.3-a1-staging/go.mod h1:JdwQA06TLpen2PL4m8Cm0fO7ovfvr1NH9w3vQU6J58M=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,8 @@ github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLD
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
-github.com/weni-ai/goflow v1.20.3-a1-staging h1:dlucZ1r1a0q2vqlU4pwa/UAuPFaARXCBu9r9fwBE990=
-github.com/weni-ai/goflow v1.20.3-a1-staging/go.mod h1:JdwQA06TLpen2PL4m8Cm0fO7ovfvr1NH9w3vQU6J58M=
+github.com/weni-ai/goflow v1.20.3 h1:zQyxMUEehbdb/ITz6JhLXa2nTgwTQn9/VGDW+9WWJxk=
+github.com/weni-ai/goflow v1.20.3/go.mod h1:JdwQA06TLpen2PL4m8Cm0fO7ovfvr1NH9w3vQU6J58M=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
### What
Handle new direct_send_template_name field

### Why
Courier needs to be able to access this field to send the template name when dispatching a direct send message