### PR TITLE
feat/generic ticketer

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.92.0
+----------
+* feat: add generic ticketer
+
 1.91.0
 ----------
 * feat: add product carousel support to WppBroadcastMessage and related tests

--- a/cmd/mailroom/main.go
+++ b/cmd/mailroom/main.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/nyaruka/mailroom/services/ivr/twiml"
 	_ "github.com/nyaruka/mailroom/services/ivr/vonage"
 	_ "github.com/nyaruka/mailroom/services/tickets/freshchat"
+	_ "github.com/nyaruka/mailroom/services/tickets/generic"
 	_ "github.com/nyaruka/mailroom/services/tickets/intern"
 	_ "github.com/nyaruka/mailroom/services/tickets/mailgun"
 	_ "github.com/nyaruka/mailroom/services/tickets/rocketchat"

--- a/services/tickets/generic/client.go
+++ b/services/tickets/generic/client.go
@@ -1,0 +1,31 @@
+package generic
+
+import (
+	"net/http"
+
+	"github.com/nyaruka/gocommon/httpx"
+)
+
+// apiVersion is the value emitted in the X-API-Version header on all
+// platform-to-ticketer requests.
+const apiVersion = "1"
+
+// Client is the HTTP client used by the generic ticketer service to call the
+// partner endpoints documented in docs/generic-ticketer-service.md.
+type Client struct {
+	httpClient  *http.Client
+	httpRetries *httpx.RetryConfig
+	baseURL     string
+	apiToken    string
+}
+
+// NewClient builds a Client targeting the given partner base URL using the
+// provided bearer token for authentication.
+func NewClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, baseURL, apiToken string) *Client {
+	return &Client{
+		httpClient:  httpClient,
+		httpRetries: httpRetries,
+		baseURL:     baseURL,
+		apiToken:    apiToken,
+	}
+}

--- a/services/tickets/generic/client.go
+++ b/services/tickets/generic/client.go
@@ -1,14 +1,85 @@
 package generic
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/jsonx"
+	"github.com/nyaruka/gocommon/uuids"
+	"github.com/pkg/errors"
 )
 
-// apiVersion is the value emitted in the X-API-Version header on all
-// platform-to-ticketer requests.
+// apiVersion is the contract version emitted in the X-API-Version header on
+// every platform-to-ticketer request. See docs/generic-ticketer-service.md.
 const apiVersion = "1"
+
+// externalIDPlaceholder is the token replaced in route templates by the
+// URL-escaped external_id of the ticket at request time.
+const externalIDPlaceholder = "{external_id}"
+
+// Routes lets callers override per-endpoint path templates on the partner
+// side. Empty fields are filled in by WithDefaults, so callers can override
+// just the routes they need. Templates may contain the {external_id}
+// placeholder, which is URL-escaped at request time.
+type Routes struct {
+	OpenTicket     string
+	ForwardMessage string
+	CloseTicket    string
+	ReopenTicket   string
+	SendHistory    string
+}
+
+// DefaultRoutes returns the opinionated route templates that match the
+// generic ticketer contract documented in docs/generic-ticketer-service.md.
+func DefaultRoutes() Routes {
+	return Routes{
+		OpenTicket:     "/v1/tickets",
+		ForwardMessage: "/v1/tickets/" + externalIDPlaceholder + "/messages",
+		CloseTicket:    "/v1/tickets/" + externalIDPlaceholder + "/close",
+		ReopenTicket:   "/v1/tickets/" + externalIDPlaceholder + "/reopen",
+		SendHistory:    "/v1/tickets/" + externalIDPlaceholder + "/history",
+	}
+}
+
+// WithDefaults returns a copy of r where empty fields are filled in from d.
+func (r Routes) WithDefaults(d Routes) Routes {
+	if r.OpenTicket == "" {
+		r.OpenTicket = d.OpenTicket
+	}
+	if r.ForwardMessage == "" {
+		r.ForwardMessage = d.ForwardMessage
+	}
+	if r.CloseTicket == "" {
+		r.CloseTicket = d.CloseTicket
+	}
+	if r.ReopenTicket == "" {
+		r.ReopenTicket = d.ReopenTicket
+	}
+	if r.SendHistory == "" {
+		r.SendHistory = d.SendHistory
+	}
+	return r
+}
+
+// ClientOption configures optional behavior on a Client at construction.
+type ClientOption func(*Client)
+
+// WithRoutes overrides one or more route templates. Empty fields fall back to
+// DefaultRoutes, so callers can supply only the routes they need to customize.
+// Should be passed at most once to NewClient — subsequent calls replace the
+// previous override.
+func WithRoutes(r Routes) ClientOption {
+	return func(c *Client) {
+		c.routes = r.WithDefaults(DefaultRoutes())
+	}
+}
 
 // Client is the HTTP client used by the generic ticketer service to call the
 // partner endpoints documented in docs/generic-ticketer-service.md.
@@ -17,15 +88,269 @@ type Client struct {
 	httpRetries *httpx.RetryConfig
 	baseURL     string
 	apiToken    string
+	routes      Routes
 }
 
 // NewClient builds a Client targeting the given partner base URL using the
-// provided bearer token for authentication.
-func NewClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, baseURL, apiToken string) *Client {
-	return &Client{
+// provided bearer token for authentication. Trailing slashes in baseURL are
+// stripped. Route templates default to DefaultRoutes; pass WithRoutes to
+// override them.
+func NewClient(httpClient *http.Client, httpRetries *httpx.RetryConfig, baseURL, apiToken string, opts ...ClientOption) *Client {
+	c := &Client{
 		httpClient:  httpClient,
 		httpRetries: httpRetries,
-		baseURL:     baseURL,
+		baseURL:     strings.TrimRight(baseURL, "/"),
 		apiToken:    apiToken,
+		routes:      DefaultRoutes(),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// endpoint substitutes {external_id} in a route template with the URL-escaped
+// value, returning the resulting path.
+func (c *Client) endpoint(template, externalID string) string {
+	if !strings.Contains(template, externalIDPlaceholder) {
+		return template
+	}
+	return strings.ReplaceAll(template, externalIDPlaceholder, url.PathEscape(externalID))
+}
+
+// ClientError is returned when the partner answers with a 4xx or 5xx status
+// code. It maps to the error envelope documented in section 9 of the spec
+// ({error, message, details}).
+type ClientError struct {
+	StatusCode int             `json:"-"`
+	Code       string          `json:"error"`
+	Message    string          `json:"message"`
+	Details    json.RawMessage `json:"details,omitempty"`
+}
+
+// Error implements the error interface.
+func (e *ClientError) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	}
+	return fmt.Sprintf("HTTP %d", e.StatusCode)
+}
+
+// Shared DTOs --------------------------------------------------------------
+
+// Topic identifies the queue/subject of the ticket.
+type Topic struct {
+	UUID      string `json:"uuid"`
+	Name      string `json:"name,omitempty"`
+	QueueUUID string `json:"queue_uuid,omitempty"`
+}
+
+// Contact carries the contact data sent on open and on history.
+type Contact struct {
+	UUID     string   `json:"uuid"`
+	Name     string   `json:"name,omitempty"`
+	URN      string   `json:"urn"`
+	URNs     []string `json:"urns,omitempty"`
+	Language string   `json:"language,omitempty"`
+}
+
+// Assignee is the agent suggested at ticket open.
+type Assignee struct {
+	Email string `json:"email"`
+	Name  string `json:"name,omitempty"`
+	UUID  string `json:"uuid,omitempty"`
+}
+
+// Sender identifies who originated a message.
+type Sender struct {
+	Type  string `json:"type"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+// Attachment represents a single message attachment.
+type Attachment struct {
+	ID          string                 `json:"id,omitempty"`
+	URL         string                 `json:"url"`
+	ContentType string                 `json:"content_type,omitempty"`
+	Filename    string                 `json:"filename,omitempty"`
+	Size        int64                  `json:"size,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ActorRef identifies the actor behind a state change (close/reopen).
+type ActorRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// Open ---------------------------------------------------------------------
+
+// OpenRequest is the body of POST /v1/tickets.
+type OpenRequest struct {
+	TicketID string                 `json:"ticket_id"`
+	Topic    *Topic                 `json:"topic,omitempty"`
+	Contact  Contact                `json:"contact"`
+	Body     string                 `json:"body,omitempty"`
+	Assignee *Assignee              `json:"assignee,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	OpenedAt time.Time              `json:"opened_at"`
+}
+
+// OpenResponse is the partner reply to POST /v1/tickets.
+type OpenResponse struct {
+	ExternalID string    `json:"external_id"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// OpenTicket creates a new ticket on the partner side.
+func (c *Client) OpenTicket(req *OpenRequest, idempotencyKey string) (*OpenResponse, *httpx.Trace, error) {
+	resp := &OpenResponse{}
+	trace, err := c.request(http.MethodPost, c.endpoint(c.routes.OpenTicket, ""), req, resp, idempotencyKey)
+	return resp, trace, err
+}
+
+// Forward (incoming message) -----------------------------------------------
+
+// MessageRequest is the body of POST /v1/tickets/{external_id}/messages.
+type MessageRequest struct {
+	TicketID    string                 `json:"ticket_id"`
+	ExternalID  string                 `json:"external_id"`
+	MessageID   string                 `json:"message_id,omitempty"`
+	Direction   string                 `json:"direction"`
+	Sender      Sender                 `json:"sender"`
+	Text        string                 `json:"text,omitempty"`
+	Attachments []Attachment           `json:"attachments,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	SentAt      time.Time              `json:"sent_at"`
+}
+
+// MessageResponse is the partner reply to POST /v1/tickets/{external_id}/messages.
+type MessageResponse struct {
+	MessageExternalID string `json:"message_external_id"`
+	Status            string `json:"status"`
+}
+
+// ForwardMessage delivers an incoming message from the contact to the partner.
+func (c *Client) ForwardMessage(externalID string, req *MessageRequest, idempotencyKey string) (*MessageResponse, *httpx.Trace, error) {
+	resp := &MessageResponse{}
+	trace, err := c.request(http.MethodPost, c.endpoint(c.routes.ForwardMessage, externalID), req, resp, idempotencyKey)
+	return resp, trace, err
+}
+
+// Close --------------------------------------------------------------------
+
+// CloseRequest is the body of POST /v1/tickets/{external_id}/close.
+type CloseRequest struct {
+	TicketID   string                 `json:"ticket_id"`
+	ExternalID string                 `json:"external_id"`
+	ClosedBy   ActorRef               `json:"closed_by"`
+	Reason     string                 `json:"reason,omitempty"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+	ClosedAt   time.Time              `json:"closed_at"`
+}
+
+// CloseTicket notifies the partner that the ticket was closed on the platform.
+func (c *Client) CloseTicket(externalID string, req *CloseRequest, idempotencyKey string) (*httpx.Trace, error) {
+	return c.request(http.MethodPost, c.endpoint(c.routes.CloseTicket, externalID), req, nil, idempotencyKey)
+}
+
+// Reopen -------------------------------------------------------------------
+
+// ReopenRequest is the body of POST /v1/tickets/{external_id}/reopen.
+type ReopenRequest struct {
+	TicketID   string                 `json:"ticket_id"`
+	ExternalID string                 `json:"external_id"`
+	ReopenedBy ActorRef               `json:"reopened_by"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+	ReopenedAt time.Time              `json:"reopened_at"`
+}
+
+// ReopenTicket notifies the partner that the ticket was reopened on the platform.
+func (c *Client) ReopenTicket(externalID string, req *ReopenRequest, idempotencyKey string) (*httpx.Trace, error) {
+	return c.request(http.MethodPost, c.endpoint(c.routes.ReopenTicket, externalID), req, nil, idempotencyKey)
+}
+
+// History ------------------------------------------------------------------
+
+// HistoryMessage is one entry in the conversation history payload.
+type HistoryMessage struct {
+	MessageID   string                 `json:"message_id,omitempty"`
+	Direction   string                 `json:"direction"`
+	Sender      Sender                 `json:"sender"`
+	Text        string                 `json:"text,omitempty"`
+	Attachments []Attachment           `json:"attachments,omitempty"`
+	SentAt      time.Time              `json:"sent_at"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// HistoryRequest is the body of POST /v1/tickets/{external_id}/history.
+type HistoryRequest struct {
+	TicketID   string                 `json:"ticket_id"`
+	ExternalID string                 `json:"external_id"`
+	Contact    Contact                `json:"contact"`
+	Messages   []HistoryMessage       `json:"messages"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// SendHistory delivers the conversation history that preceded the ticket open.
+func (c *Client) SendHistory(externalID string, req *HistoryRequest, idempotencyKey string) (*httpx.Trace, error) {
+	return c.request(http.MethodPost, c.endpoint(c.routes.SendHistory, externalID), req, nil, idempotencyKey)
+}
+
+// Internal -----------------------------------------------------------------
+
+func (c *Client) request(method, endpoint string, payload, response interface{}, idempotencyKey string) (*httpx.Trace, error) {
+	fullURL := c.baseURL + endpoint
+
+	headers := map[string]string{
+		"Authorization": "Bearer " + c.apiToken,
+		"Content-Type":  "application/json",
+		"X-API-Version": apiVersion,
+		"X-Request-Id":  string(uuids.New()),
+	}
+	if idempotencyKey != "" {
+		headers["Idempotency-Key"] = idempotencyKey
+	}
+
+	var body io.Reader
+	if payload != nil {
+		data, err := jsonx.Marshal(payload)
+		if err != nil {
+			return nil, errors.Wrap(err, "error marshalling request payload")
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := httpx.NewRequest(method, fullURL, body, headers)
+	if err != nil {
+		return nil, err
+	}
+
+	trace, err := httpx.DoTrace(c.httpClient, req, c.httpRetries, nil, -1)
+	if err != nil {
+		return trace, err
+	}
+
+	if trace.Response.StatusCode >= 400 {
+		clientErr := &ClientError{StatusCode: trace.Response.StatusCode}
+		if len(trace.ResponseBody) > 0 {
+			_ = jsonx.Unmarshal(trace.ResponseBody, clientErr)
+		}
+		if clientErr.Code == "" {
+			clientErr.Message = fmt.Sprintf("HTTP %d", trace.Response.StatusCode)
+		}
+		return trace, clientErr
+	}
+
+	if response != nil && len(trace.ResponseBody) > 0 {
+		if err := jsonx.Unmarshal(trace.ResponseBody, response); err != nil {
+			return trace, errors.Wrap(err, "error unmarshalling response")
+		}
+	}
+
+	return trace, nil
 }

--- a/services/tickets/generic/client_test.go
+++ b/services/tickets/generic/client_test.go
@@ -1,0 +1,438 @@
+package generic_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/mailroom/services/tickets/generic"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBaseURL  = "https://partner.example.com"
+	testAPIToken = "secret-token-123"
+)
+
+var (
+	sampleTicketUUID  = "0f4d2c8a-2c83-4f2c-9f7d-1d4f70d50e71"
+	sampleContactUUID = "7ad9d98e-321f-4c61-9a50-79b1c7d7f621"
+	sampleExternalID  = "EXT-123456"
+)
+
+func resetGlobals(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		uuids.SetGenerator(uuids.DefaultGenerator)
+		httpx.SetRequestor(httpx.DefaultRequestor)
+	})
+	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
+}
+
+func newTestClient() *generic.Client {
+	return generic.NewClient(http.DefaultClient, nil, testBaseURL, testAPIToken)
+}
+
+func openedAt() time.Time { return time.Date(2026, 5, 20, 14, 30, 0, 0, time.UTC) }
+func sentAt() time.Time   { return time.Date(2026, 5, 20, 14, 32, 0, 0, time.UTC) }
+
+func TestOpenTicket(t *testing.T) {
+	resetGlobals(t)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		testBaseURL + "/v1/tickets": {
+			httpx.MockConnectionError,
+			httpx.NewMockResponse(201, nil, `{"external_id":"EXT-123456","status":"open","created_at":"2026-05-20T14:30:03Z"}`),
+			httpx.NewMockResponse(409, nil, `{"error":"ticket_already_open","message":"An open ticket already exists","details":{"external_id":"EXT-999"}}`),
+		},
+	}))
+
+	client := newTestClient()
+
+	req := &generic.OpenRequest{
+		TicketID: sampleTicketUUID,
+		Topic:    &generic.Topic{UUID: "a1d2b8c3-9e4f-4a5b-8c6d-7e8f9a0b1c2d", Name: "Vendas"},
+		Contact: generic.Contact{
+			UUID: sampleContactUUID,
+			Name: "João Silva",
+			URN:  "whatsapp:+5511999999999",
+		},
+		Body:     "Cliente pediu atendimento humano.",
+		OpenedAt: openedAt(),
+	}
+	idemKey := "open-" + sampleTicketUUID
+
+	_, _, err := client.OpenTicket(req, idemKey)
+	assert.EqualError(t, err, "unable to connect to server")
+
+	resp, trace, err := client.OpenTicket(req, idemKey)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "EXT-123456", resp.ExternalID)
+	assert.Equal(t, "open", resp.Status)
+	assert.Equal(t, time.Date(2026, 5, 20, 14, 30, 3, 0, time.UTC), resp.CreatedAt.UTC())
+
+	require.NotNil(t, trace)
+	assert.Equal(t, "Bearer "+testAPIToken, trace.Request.Header.Get("Authorization"))
+	assert.Equal(t, "application/json", trace.Request.Header.Get("Content-Type"))
+	assert.Equal(t, "1", trace.Request.Header.Get("X-API-Version"))
+	assert.Equal(t, idemKey, trace.Request.Header.Get("Idempotency-Key"))
+	assert.NotEmpty(t, trace.Request.Header.Get("X-Request-Id"))
+	assert.Contains(t, string(trace.RequestTrace), `"ticket_id":"`+sampleTicketUUID+`"`)
+	assert.Contains(t, string(trace.RequestTrace), `"opened_at":"2026-05-20T14:30:00Z"`)
+	assert.Contains(t, string(trace.RequestTrace), `"topic":{"uuid":"a1d2b8c3-9e4f-4a5b-8c6d-7e8f9a0b1c2d","name":"Vendas"}`)
+
+	_, _, err = client.OpenTicket(req, idemKey)
+	require.Error(t, err)
+
+	var clientErr *generic.ClientError
+	require.True(t, errors.As(err, &clientErr))
+	assert.Equal(t, 409, clientErr.StatusCode)
+	assert.Equal(t, "ticket_already_open", clientErr.Code)
+	assert.Equal(t, "An open ticket already exists", clientErr.Message)
+	assert.Contains(t, string(clientErr.Details), "EXT-999")
+}
+
+func TestForwardMessage(t *testing.T) {
+	resetGlobals(t)
+
+	endpoint := testBaseURL + "/v1/tickets/" + sampleExternalID + "/messages"
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		endpoint: {
+			httpx.MockConnectionError,
+			httpx.NewMockResponse(200, nil, `{"message_external_id":"external-msg-456","status":"received"}`),
+		},
+	}))
+
+	client := newTestClient()
+	req := &generic.MessageRequest{
+		TicketID:   sampleTicketUUID,
+		ExternalID: sampleExternalID,
+		MessageID:  "msg-789",
+		Direction:  "incoming",
+		Sender:     generic.Sender{Type: "contact", ID: sampleContactUUID, Name: "João Silva"},
+		Text:       "Olá, preciso de ajuda com meu pedido.",
+		SentAt:     sentAt(),
+	}
+	idemKey := "forward-msg-789"
+
+	_, _, err := client.ForwardMessage(sampleExternalID, req, idemKey)
+	assert.EqualError(t, err, "unable to connect to server")
+
+	resp, trace, err := client.ForwardMessage(sampleExternalID, req, idemKey)
+	require.NoError(t, err)
+	assert.Equal(t, "external-msg-456", resp.MessageExternalID)
+	assert.Equal(t, "received", resp.Status)
+	assert.Equal(t, idemKey, trace.Request.Header.Get("Idempotency-Key"))
+	assert.Contains(t, string(trace.RequestTrace), `"direction":"incoming"`)
+	assert.Contains(t, string(trace.RequestTrace), `"sender":{"type":"contact","id":"`+sampleContactUUID+`","name":"João Silva"}`)
+}
+
+func TestForwardMessageEscapesExternalID(t *testing.T) {
+	resetGlobals(t)
+
+	rawID := "EXT/with/slashes"
+	endpoint := testBaseURL + "/v1/tickets/EXT%2Fwith%2Fslashes/messages"
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		endpoint: {
+			httpx.NewMockResponse(200, nil, `{"message_external_id":"x","status":"received"}`),
+		},
+	}))
+
+	client := newTestClient()
+	req := &generic.MessageRequest{
+		TicketID:   sampleTicketUUID,
+		ExternalID: rawID,
+		Direction:  "incoming",
+		Sender:     generic.Sender{Type: "contact"},
+		Text:       "hi",
+		SentAt:     sentAt(),
+	}
+
+	_, _, err := client.ForwardMessage(rawID, req, "")
+	require.NoError(t, err)
+}
+
+func TestCloseTicket(t *testing.T) {
+	resetGlobals(t)
+
+	endpoint := testBaseURL + "/v1/tickets/" + sampleExternalID + "/close"
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		endpoint: {
+			httpx.NewMockResponse(200, nil, `{"status":"closed"}`),
+			httpx.NewMockResponse(409, nil, `{"error":"ticket_already_closed","message":"Ticket is already closed"}`),
+		},
+	}))
+
+	client := newTestClient()
+	req := &generic.CloseRequest{
+		TicketID:   sampleTicketUUID,
+		ExternalID: sampleExternalID,
+		ClosedBy:   generic.ActorRef{Type: "platform", ID: "system"},
+		Reason:     "resolved",
+		ClosedAt:   time.Date(2026, 5, 20, 14, 50, 0, 0, time.UTC),
+	}
+	idemKey := "close-" + sampleTicketUUID + "-evt1"
+
+	trace, err := client.CloseTicket(sampleExternalID, req, idemKey)
+	require.NoError(t, err)
+	assert.Equal(t, idemKey, trace.Request.Header.Get("Idempotency-Key"))
+	assert.Contains(t, string(trace.RequestTrace), `"closed_by":{"type":"platform","id":"system"}`)
+	assert.Contains(t, string(trace.RequestTrace), `"reason":"resolved"`)
+
+	_, err = client.CloseTicket(sampleExternalID, req, idemKey)
+	require.Error(t, err)
+
+	var clientErr *generic.ClientError
+	require.True(t, errors.As(err, &clientErr))
+	assert.Equal(t, 409, clientErr.StatusCode)
+	assert.Equal(t, "ticket_already_closed", clientErr.Code)
+}
+
+func TestReopenTicket(t *testing.T) {
+	resetGlobals(t)
+
+	endpoint := testBaseURL + "/v1/tickets/" + sampleExternalID + "/reopen"
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		endpoint: {
+			httpx.NewMockResponse(200, nil, `{"status":"open"}`),
+			httpx.NewMockResponse(422, nil, `{"error":"reopen_not_supported","message":"This ticketer does not support ticket reopening"}`),
+		},
+	}))
+
+	client := newTestClient()
+	req := &generic.ReopenRequest{
+		TicketID:   sampleTicketUUID,
+		ExternalID: sampleExternalID,
+		ReopenedBy: generic.ActorRef{Type: "platform", ID: "system"},
+		ReopenedAt: time.Date(2026, 5, 20, 15, 5, 0, 0, time.UTC),
+	}
+
+	_, err := client.ReopenTicket(sampleExternalID, req, "reopen-"+sampleTicketUUID+"-evt1")
+	require.NoError(t, err)
+
+	_, err = client.ReopenTicket(sampleExternalID, req, "reopen-"+sampleTicketUUID+"-evt2")
+	require.Error(t, err)
+
+	var clientErr *generic.ClientError
+	require.True(t, errors.As(err, &clientErr))
+	assert.Equal(t, 422, clientErr.StatusCode)
+	assert.Equal(t, "reopen_not_supported", clientErr.Code)
+}
+
+func TestSendHistory(t *testing.T) {
+	resetGlobals(t)
+
+	endpoint := testBaseURL + "/v1/tickets/" + sampleExternalID + "/history"
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		endpoint: {
+			httpx.NewMockResponse(200, nil, `{"status":"history_received","messages_received":2}`),
+		},
+	}))
+
+	client := newTestClient()
+	req := &generic.HistoryRequest{
+		TicketID:   sampleTicketUUID,
+		ExternalID: sampleExternalID,
+		Contact: generic.Contact{
+			UUID: sampleContactUUID,
+			Name: "João Silva",
+			URN:  "whatsapp:+5511999999999",
+		},
+		Messages: []generic.HistoryMessage{
+			{
+				MessageID: "msg-001",
+				Direction: "outgoing",
+				Sender:    generic.Sender{Type: "bot"},
+				Text:      "Olá! Como posso ajudar?",
+				SentAt:    time.Date(2026, 5, 20, 14, 20, 0, 0, time.UTC),
+			},
+			{
+				MessageID: "msg-002",
+				Direction: "incoming",
+				Sender:    generic.Sender{Type: "contact", ID: sampleContactUUID},
+				Text:      "Quero falar com um atendente.",
+				SentAt:    time.Date(2026, 5, 20, 14, 21, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	trace, err := client.SendHistory(sampleExternalID, req, "")
+	require.NoError(t, err)
+	assert.Contains(t, string(trace.RequestTrace), `"messages":[`)
+	assert.Contains(t, string(trace.RequestTrace), `"message_id":"msg-001"`)
+	assert.Contains(t, string(trace.RequestTrace), `"message_id":"msg-002"`)
+}
+
+func TestRequestWithoutIdempotencyKey(t *testing.T) {
+	resetGlobals(t)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		testBaseURL + "/v1/tickets": {
+			httpx.NewMockResponse(201, nil, `{"external_id":"EXT-1","status":"open","created_at":"2026-05-20T14:30:03Z"}`),
+		},
+	}))
+
+	client := newTestClient()
+	req := &generic.OpenRequest{
+		TicketID: sampleTicketUUID,
+		Contact:  generic.Contact{UUID: sampleContactUUID, URN: "whatsapp:+551199"},
+		OpenedAt: openedAt(),
+	}
+
+	_, trace, err := client.OpenTicket(req, "")
+	require.NoError(t, err)
+	assert.Empty(t, trace.Request.Header.Get("Idempotency-Key"))
+}
+
+func TestNewClientStripsTrailingSlash(t *testing.T) {
+	resetGlobals(t)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		testBaseURL + "/v1/tickets": {
+			httpx.NewMockResponse(201, nil, `{"external_id":"EXT-1","status":"open","created_at":"2026-05-20T14:30:03Z"}`),
+		},
+	}))
+
+	client := generic.NewClient(http.DefaultClient, nil, testBaseURL+"/", testAPIToken)
+	_, _, err := client.OpenTicket(&generic.OpenRequest{
+		TicketID: sampleTicketUUID,
+		Contact:  generic.Contact{UUID: sampleContactUUID, URN: "whatsapp:+551199"},
+		OpenedAt: openedAt(),
+	}, "")
+	require.NoError(t, err)
+}
+
+func TestDefaultRoutes(t *testing.T) {
+	routes := generic.DefaultRoutes()
+	assert.Equal(t, "/v1/tickets", routes.OpenTicket)
+	assert.Equal(t, "/v1/tickets/{external_id}/messages", routes.ForwardMessage)
+	assert.Equal(t, "/v1/tickets/{external_id}/close", routes.CloseTicket)
+	assert.Equal(t, "/v1/tickets/{external_id}/reopen", routes.ReopenTicket)
+	assert.Equal(t, "/v1/tickets/{external_id}/history", routes.SendHistory)
+
+	defaults := generic.DefaultRoutes()
+	defaults.OpenTicket = "mutated"
+	assert.Equal(t, "/v1/tickets", generic.DefaultRoutes().OpenTicket, "DefaultRoutes() must return a fresh copy")
+}
+
+func TestRoutesWithDefaults(t *testing.T) {
+	merged := generic.Routes{OpenTicket: "/custom/open"}.WithDefaults(generic.DefaultRoutes())
+	assert.Equal(t, "/custom/open", merged.OpenTicket)
+	assert.Equal(t, "/v1/tickets/{external_id}/messages", merged.ForwardMessage)
+	assert.Equal(t, "/v1/tickets/{external_id}/close", merged.CloseTicket)
+}
+
+func TestCustomRoutes(t *testing.T) {
+	resetGlobals(t)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		testBaseURL + "/api/conversations": {
+			httpx.NewMockResponse(201, nil, `{"external_id":"`+sampleExternalID+`","status":"open","created_at":"2026-05-20T14:30:03Z"}`),
+		},
+		testBaseURL + "/api/conversations/" + sampleExternalID + "/inbound": {
+			httpx.NewMockResponse(200, nil, `{"message_external_id":"x","status":"received"}`),
+		},
+		testBaseURL + "/api/conversations/" + sampleExternalID + "/close": {
+			httpx.NewMockResponse(200, nil, `{"status":"closed"}`),
+		},
+		testBaseURL + "/api/conversations/" + sampleExternalID + "/reopen": {
+			httpx.NewMockResponse(200, nil, `{"status":"open"}`),
+		},
+		testBaseURL + "/api/conversations/" + sampleExternalID + "/history": {
+			httpx.NewMockResponse(200, nil, `{"status":"history_received","messages_received":0}`),
+		},
+	}))
+
+	client := generic.NewClient(http.DefaultClient, nil, testBaseURL, testAPIToken, generic.WithRoutes(generic.Routes{
+		OpenTicket:     "/api/conversations",
+		ForwardMessage: "/api/conversations/{external_id}/inbound",
+		CloseTicket:    "/api/conversations/{external_id}/close",
+		ReopenTicket:   "/api/conversations/{external_id}/reopen",
+		SendHistory:    "/api/conversations/{external_id}/history",
+	}))
+
+	contact := generic.Contact{UUID: sampleContactUUID, URN: "whatsapp:+551199"}
+
+	_, _, err := client.OpenTicket(&generic.OpenRequest{TicketID: sampleTicketUUID, Contact: contact, OpenedAt: openedAt()}, "")
+	require.NoError(t, err)
+
+	_, _, err = client.ForwardMessage(sampleExternalID, &generic.MessageRequest{
+		TicketID: sampleTicketUUID, ExternalID: sampleExternalID, Direction: "incoming",
+		Sender: generic.Sender{Type: "contact"}, Text: "hi", SentAt: sentAt(),
+	}, "")
+	require.NoError(t, err)
+
+	_, err = client.CloseTicket(sampleExternalID, &generic.CloseRequest{
+		TicketID: sampleTicketUUID, ExternalID: sampleExternalID,
+		ClosedBy: generic.ActorRef{Type: "platform"}, ClosedAt: openedAt(),
+	}, "")
+	require.NoError(t, err)
+
+	_, err = client.ReopenTicket(sampleExternalID, &generic.ReopenRequest{
+		TicketID: sampleTicketUUID, ExternalID: sampleExternalID,
+		ReopenedBy: generic.ActorRef{Type: "platform"}, ReopenedAt: openedAt(),
+	}, "")
+	require.NoError(t, err)
+
+	_, err = client.SendHistory(sampleExternalID, &generic.HistoryRequest{
+		TicketID: sampleTicketUUID, ExternalID: sampleExternalID, Contact: contact, Messages: []generic.HistoryMessage{},
+	}, "")
+	require.NoError(t, err)
+}
+
+func TestCustomRoutesPartialOverride(t *testing.T) {
+	resetGlobals(t)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		testBaseURL + "/api/conversations": {
+			httpx.NewMockResponse(201, nil, `{"external_id":"`+sampleExternalID+`","status":"open","created_at":"2026-05-20T14:30:03Z"}`),
+		},
+		testBaseURL + "/v1/tickets/" + sampleExternalID + "/messages": {
+			httpx.NewMockResponse(200, nil, `{"message_external_id":"x","status":"received"}`),
+		},
+	}))
+
+	client := generic.NewClient(http.DefaultClient, nil, testBaseURL, testAPIToken, generic.WithRoutes(generic.Routes{
+		OpenTicket: "/api/conversations",
+	}))
+
+	contact := generic.Contact{UUID: sampleContactUUID, URN: "whatsapp:+551199"}
+
+	_, _, err := client.OpenTicket(&generic.OpenRequest{TicketID: sampleTicketUUID, Contact: contact, OpenedAt: openedAt()}, "")
+	require.NoError(t, err, "custom OpenTicket route must be used")
+
+	_, _, err = client.ForwardMessage(sampleExternalID, &generic.MessageRequest{
+		TicketID: sampleTicketUUID, ExternalID: sampleExternalID, Direction: "incoming",
+		Sender: generic.Sender{Type: "contact"}, Text: "hi", SentAt: sentAt(),
+	}, "")
+	require.NoError(t, err, "ForwardMessage must fall back to DefaultRoutes when not overridden")
+}
+
+func TestClientErrorOnMalformedErrorBody(t *testing.T) {
+	resetGlobals(t)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		testBaseURL + "/v1/tickets": {
+			httpx.NewMockResponse(500, nil, `not json`),
+		},
+	}))
+
+	client := newTestClient()
+	_, _, err := client.OpenTicket(&generic.OpenRequest{
+		TicketID: sampleTicketUUID,
+		Contact:  generic.Contact{UUID: sampleContactUUID, URN: "whatsapp:+551199"},
+		OpenedAt: openedAt(),
+	}, "")
+	require.Error(t, err)
+
+	var clientErr *generic.ClientError
+	require.True(t, errors.As(err, &clientErr))
+	assert.Equal(t, 500, clientErr.StatusCode)
+	assert.Equal(t, "HTTP 500", clientErr.Error())
+}

--- a/services/tickets/generic/service.go
+++ b/services/tickets/generic/service.go
@@ -7,6 +7,7 @@
 package generic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -75,7 +76,8 @@ type service struct {
 // NewService creates a new generic ticket service from the given config map.
 // Required keys: base_url, api_token. webhook_secret is required unless
 // skip_webhook_hmac is true.
-func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, model *models.Ticketer, ctx context.Context, db models.Queryer) (models.TicketService, error) {
+	config := model.ConfigMap()
 	baseURL := strings.TrimSpace(config[configBaseURL])
 	apiToken := strings.TrimSpace(config[configAPIToken])
 	webhookSecret := strings.TrimSpace(config[configWebhookSecret])

--- a/services/tickets/generic/service.go
+++ b/services/tickets/generic/service.go
@@ -8,9 +8,13 @@ package generic
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
@@ -22,9 +26,25 @@ import (
 const (
 	typeGeneric = "generic"
 
+	// Required config
 	configBaseURL       = "base_url"
 	configAPIToken      = "api_token"
 	configWebhookSecret = "webhook_secret"
+
+	// Optional metadata enrichment for partner-side context
+	configProjectUUID = "project_uuid"
+	configProjectName = "project_name"
+
+	// Optional per-endpoint route overrides. When empty, DefaultRoutes is used.
+	configRouteOpen    = "route_open"
+	configRouteForward = "route_forward"
+	configRouteClose   = "route_close"
+	configRouteReopen  = "route_reopen"
+	configRouteHistory = "route_history"
+
+	// Webhook URL pattern (legacy, kept for compatibility with existing
+	// ticketer webhook handlers in Mailroom).
+	webhookBasePath = "/mr/tickets/types/" + typeGeneric + "/event_callback"
 )
 
 func init() {
@@ -32,46 +52,305 @@ func init() {
 }
 
 type service struct {
-	rtConfig *runtime.Config
-	client   *Client
-	ticketer *flows.Ticketer
-	redactor utils.Redactor
+	rtConfig    *runtime.Config
+	client      *Client
+	ticketer    *flows.Ticketer
+	redactor    utils.Redactor
+	projectUUID string
+	projectName string
 }
 
-// NewService creates a new generic ticket service.
+// NewService creates a new generic ticket service from the given config map.
+// Required keys: base_url, api_token, webhook_secret.
 func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
-	baseURL := config[configBaseURL]
-	apiToken := config[configAPIToken]
-	webhookSecret := config[configWebhookSecret]
+	baseURL := strings.TrimSpace(config[configBaseURL])
+	apiToken := strings.TrimSpace(config[configAPIToken])
+	webhookSecret := strings.TrimSpace(config[configWebhookSecret])
 
 	if baseURL == "" || apiToken == "" || webhookSecret == "" {
 		return nil, errors.New("missing base_url, api_token or webhook_secret in generic ticketer config")
 	}
 
+	routes := Routes{
+		OpenTicket:     config[configRouteOpen],
+		ForwardMessage: config[configRouteForward],
+		CloseTicket:    config[configRouteClose],
+		ReopenTicket:   config[configRouteReopen],
+		SendHistory:    config[configRouteHistory],
+	}
+
 	return &service{
-		rtConfig: rtCfg,
-		client:   NewClient(httpClient, httpRetries, baseURL, apiToken),
-		ticketer: ticketer,
-		redactor: utils.NewRedactor(flows.RedactionMask, apiToken, webhookSecret),
+		rtConfig:    rtCfg,
+		client:      NewClient(httpClient, httpRetries, baseURL, apiToken, WithRoutes(routes)),
+		ticketer:    ticketer,
+		redactor:    utils.NewRedactor(flows.RedactionMask, apiToken, webhookSecret),
+		projectUUID: config[configProjectUUID],
+		projectName: config[configProjectName],
 	}, nil
 }
 
+// Open opens a new ticket on the partner side, mapping Mailroom session +
+// topic + assignee into the OpenRequest documented in section 2.1 of the
+// spec.
 func (s *service) Open(session flows.Session, topic *flows.Topic, body string, assignee *flows.User, logHTTP flows.HTTPLogCallback) (*flows.Ticket, error) {
-	return nil, errors.New("generic ticketer Open not implemented")
+	ticket := flows.OpenTicket(s.ticketer, topic, body, assignee)
+	contact := session.Contact()
+
+	contactDTO := Contact{
+		UUID:     string(contact.UUID()),
+		Name:     contact.Name(),
+		Language: string(contact.Language()),
+	}
+
+	// Respect the org-level redaction policy: anonymize the contact name
+	// when URNs would otherwise leak identity.
+	if session.Environment().RedactionPolicy() == envs.RedactionPolicyURNs {
+		contactDTO.Name = fmt.Sprintf("%d", contact.ID())
+	}
+
+	if preferred := contact.PreferredURN(); preferred != nil {
+		contactDTO.URN = preferred.URN().String()
+	} else if urnList := contact.URNs(); len(urnList) > 0 {
+		contactDTO.URN = urnList[0].URN().String()
+	} else {
+		return nil, errors.New("contact has no URNs to open generic ticket with")
+	}
+	for _, u := range contact.URNs() {
+		contactDTO.URNs = append(contactDTO.URNs, u.URN().String())
+	}
+
+	req := &OpenRequest{
+		TicketID: string(ticket.UUID()),
+		Contact:  contactDTO,
+		Body:     body,
+		OpenedAt: dates.Now(),
+	}
+
+	if topic != nil {
+		req.Topic = &Topic{
+			UUID:      string(topic.UUID()),
+			Name:      topic.Name(),
+			QueueUUID: string(topic.QueueUUID()),
+		}
+	}
+	if assignee != nil {
+		req.Assignee = &Assignee{
+			Email: assignee.Email(),
+			Name:  assignee.Name(),
+		}
+	}
+
+	req.Metadata = s.buildOpenMetadata(session)
+
+	idempotencyKey := "open-" + string(ticket.UUID())
+	resp, trace, err := s.client.OpenTicket(req, idempotencyKey)
+	if trace != nil {
+		logHTTP(flows.NewHTTPLog(trace, flows.HTTPStatusFromCode, s.redactor))
+	}
+	if err != nil {
+		// A 409 with an existing external_id in `details` means the partner
+		// already has this ticket open from a prior attempt — treat as
+		// success and reuse the existing external_id.
+		var ce *ClientError
+		if errors.As(err, &ce) && ce.StatusCode == http.StatusConflict && len(ce.Details) > 0 {
+			existing := &struct {
+				ExternalID string `json:"external_id"`
+			}{}
+			if jsonErr := json.Unmarshal(ce.Details, existing); jsonErr == nil && existing.ExternalID != "" {
+				ticket.SetExternalID(existing.ExternalID)
+				return ticket, nil
+			}
+		}
+		return nil, errors.Wrap(err, "error opening generic ticket")
+	}
+
+	if resp.ExternalID == "" {
+		return nil, errors.New("generic ticketer did not return an external_id")
+	}
+	ticket.SetExternalID(resp.ExternalID)
+	return ticket, nil
 }
 
+// Forward delivers an inbound contact message to the partner over the
+// MessageRequest endpoint documented in section 2.2 of the spec.
 func (s *service) Forward(ticket *models.Ticket, msgUUID flows.MsgUUID, text string, attachments []utils.Attachment, metadata json.RawMessage, msgExternalID null.String, logHTTP flows.HTTPLogCallback) error {
-	return errors.New("generic ticketer Forward not implemented")
+	externalID := string(ticket.ExternalID())
+	if externalID == "" {
+		return errors.New("cannot forward message: ticket has no external_id")
+	}
+
+	req := &MessageRequest{
+		TicketID:   string(ticket.UUID()),
+		ExternalID: externalID,
+		Direction:  "incoming",
+		Sender: Sender{
+			Type: "contact",
+			ID:   ticket.Config("contact-uuid"),
+			Name: ticket.Config("contact-display"),
+		},
+		SentAt: dates.Now(),
+	}
+
+	if string(msgUUID) != "" {
+		req.MessageID = string(msgUUID)
+	}
+	if strings.TrimSpace(text) != "" {
+		req.Text = text
+	}
+	for _, a := range attachments {
+		req.Attachments = append(req.Attachments, Attachment{
+			ContentType: a.ContentType(),
+			URL:         a.URL(),
+		})
+	}
+
+	req.Metadata = buildForwardMetadata(metadata, msgExternalID)
+
+	// Use the message UUID as the idempotency key when available so retries
+	// of the same source message are coalesced on the partner side.
+	idempotencyKey := ""
+	if string(msgUUID) != "" {
+		idempotencyKey = "forward-" + string(msgUUID)
+	}
+
+	_, trace, err := s.client.ForwardMessage(externalID, req, idempotencyKey)
+	if trace != nil {
+		logHTTP(flows.NewHTTPLog(trace, flows.HTTPStatusFromCode, s.redactor))
+	}
+	if err != nil {
+		return errors.Wrap(err, "error forwarding message to generic ticketer")
+	}
+	return nil
 }
 
+// Close notifies the partner that one or more tickets were closed on the
+// platform side. A 409 on any single ticket is treated as already-closed and
+// does not abort the loop.
 func (s *service) Close(tickets []*models.Ticket, logHTTP flows.HTTPLogCallback) error {
-	return errors.New("generic ticketer Close not implemented")
+	now := dates.Now()
+	for _, t := range tickets {
+		externalID := string(t.ExternalID())
+		if externalID == "" {
+			continue
+		}
+		req := &CloseRequest{
+			TicketID:   string(t.UUID()),
+			ExternalID: externalID,
+			ClosedBy:   ActorRef{Type: "platform", ID: "system"},
+			ClosedAt:   now,
+		}
+		idempotencyKey := fmt.Sprintf("close-%s-%d", t.UUID(), now.UnixNano())
+
+		trace, err := s.client.CloseTicket(externalID, req, idempotencyKey)
+		if trace != nil {
+			logHTTP(flows.NewHTTPLog(trace, flows.HTTPStatusFromCode, s.redactor))
+		}
+		if err != nil {
+			var ce *ClientError
+			if errors.As(err, &ce) && ce.StatusCode == http.StatusConflict {
+				continue
+			}
+			return errors.Wrapf(err, "error closing generic ticket %s", t.UUID())
+		}
+	}
+	return nil
 }
 
+// Reopen notifies the partner that one or more tickets were reopened on the
+// platform side.
 func (s *service) Reopen(tickets []*models.Ticket, logHTTP flows.HTTPLogCallback) error {
-	return errors.New("generic ticketer Reopen not implemented")
+	now := dates.Now()
+	for _, t := range tickets {
+		externalID := string(t.ExternalID())
+		if externalID == "" {
+			continue
+		}
+		req := &ReopenRequest{
+			TicketID:   string(t.UUID()),
+			ExternalID: externalID,
+			ReopenedBy: ActorRef{Type: "platform", ID: "system"},
+			ReopenedAt: now,
+		}
+		idempotencyKey := fmt.Sprintf("reopen-%s-%d", t.UUID(), now.UnixNano())
+
+		trace, err := s.client.ReopenTicket(externalID, req, idempotencyKey)
+		if trace != nil {
+			logHTTP(flows.NewHTTPLog(trace, flows.HTTPStatusFromCode, s.redactor))
+		}
+		if err != nil {
+			return errors.Wrapf(err, "error reopening generic ticket %s", t.UUID())
+		}
+	}
+	return nil
 }
 
+// SendHistory is a no-op in this stage. The optional history endpoint is part
+// of the spec (section 2.5) but DB-backed population of past contact messages
+// is deferred to a follow-up to keep this stage focused on the synchronous
+// open / forward / close / reopen flow.
 func (s *service) SendHistory(ticket *models.Ticket, contactID models.ContactID, runs []*models.FlowRun, logHTTP flows.HTTPLogCallback) error {
 	return nil
+}
+
+// buildOpenMetadata gathers the optional metadata block sent on Open. All
+// fields are best-effort — missing data is omitted rather than aborting the
+// request.
+func (s *service) buildOpenMetadata(session flows.Session) map[string]interface{} {
+	metadata := map[string]interface{}{}
+
+	if s.projectUUID != "" {
+		metadata["project_uuid"] = s.projectUUID
+	}
+	if s.projectName != "" {
+		metadata["project_name"] = s.projectName
+	}
+
+	if runs := session.Runs(); len(runs) > 0 && runs[0].Flow() != nil {
+		flow := runs[0].Flow()
+		metadata["flow"] = map[string]string{
+			"uuid": string(flow.UUID()),
+			"name": flow.Name(),
+		}
+	}
+
+	if channel := session.Contact().PreferredChannel(); channel != nil {
+		metadata["channel"] = map[string]string{
+			"uuid":    string(channel.UUID()),
+			"name":    channel.Name(),
+			"address": channel.Address(),
+		}
+	}
+
+	// Inform partner about the platform-side webhook base URL so they don't
+	// need to hard-code it. The full per-event URL is base + suffix (see
+	// section 4 of the spec).
+	if s.rtConfig != nil && s.rtConfig.Domain != "" {
+		metadata["webhook_base_url"] = fmt.Sprintf(
+			"https://%s%s/%s",
+			s.rtConfig.Domain,
+			webhookBasePath,
+			s.ticketer.UUID(),
+		)
+	}
+
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+// buildForwardMetadata merges Mailroom's per-message metadata blob with the
+// source message external_id (when present) into a single map for the partner.
+func buildForwardMetadata(raw json.RawMessage, msgExternalID null.String) map[string]interface{} {
+	out := map[string]interface{}{}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &out)
+	}
+	if msgExternalID != null.NullString && string(msgExternalID) != "" {
+		out["source_message_external_id"] = string(msgExternalID)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/services/tickets/generic/service.go
+++ b/services/tickets/generic/service.go
@@ -1,0 +1,77 @@
+// Package generic implements a generic HTTP-based ticketer service.
+//
+// The contract spoken by this ticketer is documented in
+// docs/generic-ticketer-service.md. Any partner that implements the documented
+// HTTP endpoints can plug into the platform as a ticketer without requiring
+// custom code in Mailroom.
+package generic
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/utils"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
+	"github.com/nyaruka/null"
+	"github.com/pkg/errors"
+)
+
+const (
+	typeGeneric = "generic"
+
+	configBaseURL       = "base_url"
+	configAPIToken      = "api_token"
+	configWebhookSecret = "webhook_secret"
+)
+
+func init() {
+	models.RegisterTicketService(typeGeneric, NewService)
+}
+
+type service struct {
+	rtConfig *runtime.Config
+	client   *Client
+	ticketer *flows.Ticketer
+	redactor utils.Redactor
+}
+
+// NewService creates a new generic ticket service.
+func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
+	baseURL := config[configBaseURL]
+	apiToken := config[configAPIToken]
+	webhookSecret := config[configWebhookSecret]
+
+	if baseURL == "" || apiToken == "" || webhookSecret == "" {
+		return nil, errors.New("missing base_url, api_token or webhook_secret in generic ticketer config")
+	}
+
+	return &service{
+		rtConfig: rtCfg,
+		client:   NewClient(httpClient, httpRetries, baseURL, apiToken),
+		ticketer: ticketer,
+		redactor: utils.NewRedactor(flows.RedactionMask, apiToken, webhookSecret),
+	}, nil
+}
+
+func (s *service) Open(session flows.Session, topic *flows.Topic, body string, assignee *flows.User, logHTTP flows.HTTPLogCallback) (*flows.Ticket, error) {
+	return nil, errors.New("generic ticketer Open not implemented")
+}
+
+func (s *service) Forward(ticket *models.Ticket, msgUUID flows.MsgUUID, text string, attachments []utils.Attachment, metadata json.RawMessage, msgExternalID null.String, logHTTP flows.HTTPLogCallback) error {
+	return errors.New("generic ticketer Forward not implemented")
+}
+
+func (s *service) Close(tickets []*models.Ticket, logHTTP flows.HTTPLogCallback) error {
+	return errors.New("generic ticketer Close not implemented")
+}
+
+func (s *service) Reopen(tickets []*models.Ticket, logHTTP flows.HTTPLogCallback) error {
+	return errors.New("generic ticketer Reopen not implemented")
+}
+
+func (s *service) SendHistory(ticket *models.Ticket, contactID models.ContactID, runs []*models.FlowRun, logHTTP flows.HTTPLogCallback) error {
+	return nil
+}

--- a/services/tickets/generic/service.go
+++ b/services/tickets/generic/service.go
@@ -29,7 +29,8 @@ const (
 	// Required config
 	configBaseURL       = "base_url"
 	configAPIToken      = "api_token"
-	configWebhookSecret = "webhook_secret"
+	configWebhookSecret   = "webhook_secret"
+	configSkipWebhookHMAC = "skip_webhook_hmac"
 
 	// Optional metadata enrichment for partner-side context
 	configProjectUUID = "project_uuid"
@@ -51,6 +52,17 @@ func init() {
 	models.RegisterTicketService(typeGeneric, NewService)
 }
 
+// skipWebhookHMAC reports whether inbound webhook HMAC verification is
+// disabled for this ticketer. Accepts "true", "1" or "yes" (case-insensitive).
+func skipWebhookHMAC(config map[string]string) bool {
+	return skipWebhookHMACValue(config[configSkipWebhookHMAC])
+}
+
+func skipWebhookHMACValue(value string) bool {
+	v := strings.TrimSpace(strings.ToLower(value))
+	return v == "true" || v == "1" || v == "yes"
+}
+
 type service struct {
 	rtConfig    *runtime.Config
 	client      *Client
@@ -61,13 +73,18 @@ type service struct {
 }
 
 // NewService creates a new generic ticket service from the given config map.
-// Required keys: base_url, api_token, webhook_secret.
+// Required keys: base_url, api_token. webhook_secret is required unless
+// skip_webhook_hmac is true.
 func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *httpx.RetryConfig, ticketer *flows.Ticketer, config map[string]string) (models.TicketService, error) {
 	baseURL := strings.TrimSpace(config[configBaseURL])
 	apiToken := strings.TrimSpace(config[configAPIToken])
 	webhookSecret := strings.TrimSpace(config[configWebhookSecret])
+	skipHMAC := skipWebhookHMAC(config)
 
-	if baseURL == "" || apiToken == "" || webhookSecret == "" {
+	if baseURL == "" || apiToken == "" {
+		return nil, errors.New("missing base_url, api_token or webhook_secret in generic ticketer config")
+	}
+	if !skipHMAC && webhookSecret == "" {
 		return nil, errors.New("missing base_url, api_token or webhook_secret in generic ticketer config")
 	}
 
@@ -79,11 +96,16 @@ func NewService(rtCfg *runtime.Config, httpClient *http.Client, httpRetries *htt
 		SendHistory:    config[configRouteHistory],
 	}
 
+	redactArgs := []string{apiToken}
+	if webhookSecret != "" {
+		redactArgs = append(redactArgs, webhookSecret)
+	}
+
 	return &service{
 		rtConfig:    rtCfg,
 		client:      NewClient(httpClient, httpRetries, baseURL, apiToken, WithRoutes(routes)),
 		ticketer:    ticketer,
-		redactor:    utils.NewRedactor(flows.RedactionMask, apiToken, webhookSecret),
+		redactor:    utils.NewRedactor(flows.RedactionMask, redactArgs...),
 		projectUUID: config[configProjectUUID],
 		projectName: config[configProjectName],
 	}, nil

--- a/services/tickets/generic/service_test.go
+++ b/services/tickets/generic/service_test.go
@@ -81,6 +81,14 @@ func TestNewServiceConfigValidation(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, svc)
+
+	svc, err = generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":          svcBaseURL,
+		"api_token":         svcAPIToken,
+		"skip_webhook_hmac": "true",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, svc)
 }
 
 func TestOpenAndForward(t *testing.T) {

--- a/services/tickets/generic/service_test.go
+++ b/services/tickets/generic/service_test.go
@@ -1,6 +1,7 @@
 package generic_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -52,6 +53,17 @@ func newDefaultTopic() *flows.Topic {
 	))
 }
 
+func newModelTicketer(config map[string]string) *models.Ticketer {
+	return models.BuildTicketer(
+		models.TicketerID(1),
+		assets.TicketerUUID("11111111-2222-3333-4444-555555555555"),
+		testdata.Org1.ID,
+		"generic",
+		"Generic Partner",
+		config,
+	)
+}
+
 func TestNewServiceConfigValidation(t *testing.T) {
 	_, rt, _, _ := testsuite.Get()
 
@@ -69,24 +81,24 @@ func TestNewServiceConfigValidation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, tc.config)
+			_, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(tc.config), context.Background(), nil)
 			assert.EqualError(t, err, "missing base_url, api_token or webhook_secret in generic ticketer config")
 		})
 	}
 
-	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":       svcBaseURL,
 		"api_token":      svcAPIToken,
 		"webhook_secret": svcWebhookSecret,
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 
-	svc, err = generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err = generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":          svcBaseURL,
 		"api_token":         svcAPIToken,
 		"skip_webhook_hmac": "true",
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, svc)
 }
@@ -123,13 +135,13 @@ func TestOpenAndForward(t *testing.T) {
 	}))
 
 	ticketer := newTicketer()
-	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":       svcBaseURL,
 		"api_token":      svcAPIToken,
 		"webhook_secret": svcWebhookSecret,
 		"project_uuid":   "f0e1d2c3-b4a5-4968-8c7d-9e0f1a2b3c4d",
 		"project_name":   "Partner Project",
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 
 	defaultTopic := newDefaultTopic()
@@ -237,11 +249,11 @@ func TestOpenAlreadyOpenIsTreatedAsSuccess(t *testing.T) {
 	}))
 
 	ticketer := newTicketer()
-	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":       svcBaseURL,
 		"api_token":      svcAPIToken,
 		"webhook_secret": svcWebhookSecret,
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 
 	defaultTopic := newDefaultTopic()
@@ -273,11 +285,11 @@ func TestOpenPartnerError(t *testing.T) {
 	}))
 
 	ticketer := newTicketer()
-	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":       svcBaseURL,
 		"api_token":      svcAPIToken,
 		"webhook_secret": svcWebhookSecret,
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 
 	defaultTopic := newDefaultTopic()
@@ -319,11 +331,11 @@ func TestCloseAndReopen(t *testing.T) {
 	}))
 
 	ticketer := newTicketer()
-	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":       svcBaseURL,
 		"api_token":      svcAPIToken,
 		"webhook_secret": svcWebhookSecret,
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 
 	ticketA := models.NewTicket("88bfa1dc-be33-45c2-b469-294ecb0eba90", testdata.Org1.ID, testdata.Cathy.ID, testdata.RocketChat.ID, "EXT-A", testdata.DefaultTopic.ID, "first", models.NilUserID, nil)
@@ -365,11 +377,11 @@ func TestSendHistoryIsNoop(t *testing.T) {
 	httpx.SetRequestor(httpx.NewMockRequestor(nil))
 
 	ticketer := newTicketer()
-	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":       svcBaseURL,
 		"api_token":      svcAPIToken,
 		"webhook_secret": svcWebhookSecret,
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 
 	dbTicket := models.NewTicket("88bfa1dc-be33-45c2-b469-294ecb0eba90", testdata.Org1.ID, testdata.Cathy.ID, testdata.RocketChat.ID, "EXT-X", testdata.DefaultTopic.ID, "x", models.NilUserID, nil)
@@ -399,12 +411,12 @@ func TestCustomRoutesThroughConfig(t *testing.T) {
 	}))
 
 	ticketer := newTicketer()
-	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, newModelTicketer(map[string]string{
 		"base_url":       svcBaseURL,
 		"api_token":      svcAPIToken,
 		"webhook_secret": svcWebhookSecret,
 		"route_open":     "/api/conversations",
-	})
+	}), context.Background(), nil)
 	require.NoError(t, err)
 
 	defaultTopic := newDefaultTopic()

--- a/services/tickets/generic/service_test.go
+++ b/services/tickets/generic/service_test.go
@@ -1,0 +1,411 @@
+package generic_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/assets/static"
+	"github.com/nyaruka/goflow/envs"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/test"
+	"github.com/nyaruka/goflow/utils"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/services/tickets/generic"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdata"
+	"github.com/nyaruka/null"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	svcBaseURL       = "https://partner.example.com"
+	svcAPIToken      = "svc-token"
+	svcWebhookSecret = "svc-webhook-secret"
+)
+
+// newTicketer returns an in-memory flow ticketer registered as the "generic"
+// type. The UUID is fixed so the webhook_base_url metadata field is stable
+// across tests.
+func newTicketer() *flows.Ticketer {
+	return flows.NewTicketer(static.NewTicketer(
+		assets.TicketerUUID("11111111-2222-3333-4444-555555555555"),
+		"Generic Partner",
+		"generic",
+	))
+}
+
+// newDefaultTopic constructs an in-memory General topic so tests don't need a
+// fresh OrgAssets DB query (which depends on the test DB schema being in
+// sync with the Go code).
+func newDefaultTopic() *flows.Topic {
+	return flows.NewTopic(static.NewTopic(
+		assets.TopicUUID(testdata.DefaultTopic.UUID),
+		"General",
+		assets.QueueUUID(""),
+	))
+}
+
+func TestNewServiceConfigValidation(t *testing.T) {
+	_, rt, _, _ := testsuite.Get()
+
+	ticketer := newTicketer()
+
+	cases := []struct {
+		name   string
+		config map[string]string
+	}{
+		{"empty config", map[string]string{}},
+		{"missing api_token", map[string]string{"base_url": svcBaseURL, "webhook_secret": svcWebhookSecret}},
+		{"missing webhook_secret", map[string]string{"base_url": svcBaseURL, "api_token": svcAPIToken}},
+		{"missing base_url", map[string]string{"api_token": svcAPIToken, "webhook_secret": svcWebhookSecret}},
+		{"whitespace base_url", map[string]string{"base_url": "   ", "api_token": svcAPIToken, "webhook_secret": svcWebhookSecret}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, tc.config)
+			assert.EqualError(t, err, "missing base_url, api_token or webhook_secret in generic ticketer config")
+		})
+	}
+
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":       svcBaseURL,
+		"api_token":      svcAPIToken,
+		"webhook_secret": svcWebhookSecret,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+}
+
+func TestOpenAndForward(t *testing.T) {
+	_, rt, _, _ := testsuite.Get()
+
+	defer dates.SetNowSource(dates.DefaultNowSource)
+	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2026, 5, 20, 14, 30, 0, 0, time.UTC)))
+
+	originalDomain := rt.Config.Domain
+	rt.Config.Domain = "mailroom.test"
+	defer func() { rt.Config.Domain = originalDomain }()
+
+	// CreateTestSession itself dispatches webhooks via the default requestor,
+	// so it must run before we install the mock requestor below.
+	session, _, err := test.CreateTestSession("", envs.RedactionPolicyNone)
+	require.NoError(t, err)
+
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
+
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		svcBaseURL + "/v1/tickets": {
+			httpx.MockConnectionError,
+			httpx.NewMockResponse(201, nil, `{"external_id":"EXT-OPEN-1","status":"open","created_at":"2026-05-20T14:30:01Z"}`),
+		},
+		svcBaseURL + "/v1/tickets/EXT-OPEN-1/messages": {
+			httpx.MockConnectionError,
+			httpx.NewMockResponse(202, nil, `{"message_external_id":"MSG-EXT-1","status":"queued"}`),
+			httpx.NewMockResponse(202, nil, `{"message_external_id":"MSG-EXT-2","status":"queued"}`),
+		},
+	}))
+
+	ticketer := newTicketer()
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":       svcBaseURL,
+		"api_token":      svcAPIToken,
+		"webhook_secret": svcWebhookSecret,
+		"project_uuid":   "f0e1d2c3-b4a5-4968-8c7d-9e0f1a2b3c4d",
+		"project_name":   "Partner Project",
+	})
+	require.NoError(t, err)
+
+	defaultTopic := newDefaultTopic()
+
+	// Open: first attempt returns a connection error and surfaces it.
+	logger := &flows.HTTPLogger{}
+	_, err = svc.Open(session, defaultTopic, "Need human help", nil, logger.Log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to connect to server")
+	assert.Equal(t, 1, len(logger.Logs))
+
+	// Open: second attempt succeeds and external_id is set on the ticket.
+	logger = &flows.HTTPLogger{}
+	ticket, err := svc.Open(session, defaultTopic, "Need human help", nil, logger.Log)
+	require.NoError(t, err)
+	require.NotNil(t, ticket)
+	assert.Equal(t, "General", ticket.Topic().Name())
+	assert.Equal(t, "Need human help", ticket.Body())
+	assert.Equal(t, "EXT-OPEN-1", ticket.ExternalID())
+	require.Equal(t, 1, len(logger.Logs))
+
+	openLog := logger.Logs[0]
+	assert.Contains(t, openLog.Request, "POST /v1/tickets ")
+	assert.Contains(t, openLog.Request, "Authorization: Bearer ****************")
+	// Go normalizes header names — "X-API-Version" hits the wire as
+	// "X-Api-Version".
+	assert.Contains(t, openLog.Request, "X-Api-Version: 1")
+	assert.Contains(t, openLog.Request, "Idempotency-Key: open-"+string(ticket.UUID()))
+	assert.Contains(t, openLog.Request, `"ticket_id":"`+string(ticket.UUID())+`"`)
+	assert.Contains(t, openLog.Request, `"body":"Need human help"`)
+	assert.Contains(t, openLog.Request, `"project_uuid":"f0e1d2c3-b4a5-4968-8c7d-9e0f1a2b3c4d"`)
+	assert.Contains(t, openLog.Request, `"project_name":"Partner Project"`)
+	assert.Contains(t, openLog.Request, `"webhook_base_url":"https://mailroom.test/mr/tickets/types/generic/event_callback/11111111-2222-3333-4444-555555555555"`)
+
+	// Forward: connection error
+	dbTicket := models.NewTicket(
+		ticket.UUID(),
+		testdata.Org1.ID,
+		testdata.Cathy.ID,
+		testdata.RocketChat.ID, // borrow any existing ticketer id; not persisted
+		"EXT-OPEN-1",
+		testdata.DefaultTopic.ID,
+		"Need human help",
+		models.NilUserID,
+		map[string]interface{}{
+			"contact-uuid":    string(testdata.Cathy.UUID),
+			"contact-display": "Cathy",
+		},
+	)
+
+	logger = &flows.HTTPLogger{}
+	err = svc.Forward(dbTicket, flows.MsgUUID("4fa340ae-1fb0-4666-98db-2177fe9bf31c"), "Hello!", nil, nil, null.NullString, logger.Log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to connect to server")
+
+	// Forward: text-only happy path
+	logger = &flows.HTTPLogger{}
+	err = svc.Forward(dbTicket, flows.MsgUUID("4fa340ae-1fb0-4666-98db-2177fe9bf31c"), "Hello!", nil, nil, null.NullString, logger.Log)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(logger.Logs))
+
+	fwdLog := logger.Logs[0]
+	assert.Contains(t, fwdLog.Request, "POST /v1/tickets/EXT-OPEN-1/messages ")
+	assert.Contains(t, fwdLog.Request, "Idempotency-Key: forward-4fa340ae-1fb0-4666-98db-2177fe9bf31c")
+	assert.Contains(t, fwdLog.Request, `"direction":"incoming"`)
+	assert.Contains(t, fwdLog.Request, `"sender":{"type":"contact","id":"`+string(testdata.Cathy.UUID)+`","name":"Cathy"}`)
+	assert.Contains(t, fwdLog.Request, `"text":"Hello!"`)
+	assert.NotContains(t, fwdLog.Request, `"attachments":`)
+
+	// Forward: with attachments
+	logger = &flows.HTTPLogger{}
+	attachments := []utils.Attachment{
+		"image/jpg:https://link.to/image.jpg",
+		"audio/ogg:https://link.to/audio.ogg",
+	}
+	err = svc.Forward(dbTicket, flows.MsgUUID("c0c0c0c0-d0d0-e0e0-f0f0-010203040506"), "with attach", attachments, nil, null.String("EXT-MSG-99"), logger.Log)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(logger.Logs))
+
+	fwdLog = logger.Logs[0]
+	assert.Contains(t, fwdLog.Request, `"text":"with attach"`)
+	assert.Contains(t, fwdLog.Request, `"url":"https://link.to/image.jpg"`)
+	assert.Contains(t, fwdLog.Request, `"content_type":"image/jpg"`)
+	assert.Contains(t, fwdLog.Request, `"url":"https://link.to/audio.ogg"`)
+	assert.Contains(t, fwdLog.Request, `"source_message_external_id":"EXT-MSG-99"`)
+}
+
+func TestOpenAlreadyOpenIsTreatedAsSuccess(t *testing.T) {
+	_, rt, _, _ := testsuite.Get()
+
+	defer dates.SetNowSource(dates.DefaultNowSource)
+	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2026, 5, 20, 14, 30, 0, 0, time.UTC)))
+
+	session, _, err := test.CreateTestSession("", envs.RedactionPolicyNone)
+	require.NoError(t, err)
+
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(54321))
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		svcBaseURL + "/v1/tickets": {
+			httpx.NewMockResponse(409, nil, `{"error":"ticket_already_open","message":"already exists","details":{"external_id":"EXT-EXIST-7"}}`),
+		},
+	}))
+
+	ticketer := newTicketer()
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":       svcBaseURL,
+		"api_token":      svcAPIToken,
+		"webhook_secret": svcWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	defaultTopic := newDefaultTopic()
+
+	logger := &flows.HTTPLogger{}
+	ticket, err := svc.Open(session, defaultTopic, "Need human help", nil, logger.Log)
+	require.NoError(t, err)
+	require.NotNil(t, ticket)
+	assert.Equal(t, "EXT-EXIST-7", ticket.ExternalID())
+}
+
+func TestOpenPartnerError(t *testing.T) {
+	_, rt, _, _ := testsuite.Get()
+
+	defer dates.SetNowSource(dates.DefaultNowSource)
+	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2026, 5, 20, 14, 30, 0, 0, time.UTC)))
+
+	session, _, err := test.CreateTestSession("", envs.RedactionPolicyNone)
+	require.NoError(t, err)
+
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(11111))
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		svcBaseURL + "/v1/tickets": {
+			httpx.NewMockResponse(422, nil, `{"error":"invalid_topic","message":"unknown topic uuid"}`),
+		},
+	}))
+
+	ticketer := newTicketer()
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":       svcBaseURL,
+		"api_token":      svcAPIToken,
+		"webhook_secret": svcWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	defaultTopic := newDefaultTopic()
+
+	logger := &flows.HTTPLogger{}
+	ticket, err := svc.Open(session, defaultTopic, "Need human help", nil, logger.Log)
+	assert.Nil(t, ticket)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error opening generic ticket")
+
+	var clientErr *generic.ClientError
+	require.True(t, errors.As(err, &clientErr))
+	assert.Equal(t, 422, clientErr.StatusCode)
+	assert.Equal(t, "invalid_topic", clientErr.Code)
+}
+
+func TestCloseAndReopen(t *testing.T) {
+	_, rt, _, _ := testsuite.Get()
+
+	defer dates.SetNowSource(dates.DefaultNowSource)
+	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2026, 5, 20, 14, 30, 0, 0, time.UTC)))
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(99999))
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		svcBaseURL + "/v1/tickets/EXT-A/close": {
+			httpx.NewMockResponse(204, nil, ``),
+		},
+		svcBaseURL + "/v1/tickets/EXT-B/close": {
+			httpx.NewMockResponse(409, nil, `{"error":"already_closed","message":"already closed"}`),
+		},
+		svcBaseURL + "/v1/tickets/EXT-FAIL/close": {
+			httpx.NewMockResponse(500, nil, `{"error":"server_error","message":"boom"}`),
+		},
+		svcBaseURL + "/v1/tickets/EXT-A/reopen": {
+			httpx.NewMockResponse(200, nil, ``),
+		},
+	}))
+
+	ticketer := newTicketer()
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":       svcBaseURL,
+		"api_token":      svcAPIToken,
+		"webhook_secret": svcWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	ticketA := models.NewTicket("88bfa1dc-be33-45c2-b469-294ecb0eba90", testdata.Org1.ID, testdata.Cathy.ID, testdata.RocketChat.ID, "EXT-A", testdata.DefaultTopic.ID, "first", models.NilUserID, nil)
+	ticketB := models.NewTicket("645eee60-7e84-4a9e-ade3-4fce01ae28f1", testdata.Org1.ID, testdata.Bob.ID, testdata.RocketChat.ID, "EXT-B", testdata.DefaultTopic.ID, "second", models.NilUserID, nil)
+	ticketEmpty := models.NewTicket("8aa8c4bc-9b94-4e3c-9bfe-3bb4b9ea3c61", testdata.Org1.ID, testdata.Bob.ID, testdata.RocketChat.ID, "", testdata.DefaultTopic.ID, "no-ext", models.NilUserID, nil)
+
+	// Close: a happy 204 + a 409 (already closed, ignored) + a ticket with no
+	// external_id (skipped silently).
+	logger := &flows.HTTPLogger{}
+	err = svc.Close([]*models.Ticket{ticketA, ticketB, ticketEmpty}, logger.Log)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(logger.Logs)) // empty external_id skips the call
+
+	assert.Contains(t, logger.Logs[0].Request, "POST /v1/tickets/EXT-A/close ")
+	assert.Contains(t, logger.Logs[0].Request, `"closed_by":{"type":"platform","id":"system"}`)
+	assert.Contains(t, logger.Logs[1].Request, "POST /v1/tickets/EXT-B/close ")
+
+	// Close: a 500 should bubble up as an error after logging.
+	ticketFail := models.NewTicket("0f0f0f0f-1111-2222-3333-444444444444", testdata.Org1.ID, testdata.Bob.ID, testdata.RocketChat.ID, "EXT-FAIL", testdata.DefaultTopic.ID, "bad", models.NilUserID, nil)
+	logger = &flows.HTTPLogger{}
+	err = svc.Close([]*models.Ticket{ticketFail}, logger.Log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error closing generic ticket")
+	assert.Equal(t, 1, len(logger.Logs))
+
+	// Reopen: happy path
+	logger = &flows.HTTPLogger{}
+	err = svc.Reopen([]*models.Ticket{ticketA}, logger.Log)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(logger.Logs))
+	assert.Contains(t, logger.Logs[0].Request, "POST /v1/tickets/EXT-A/reopen ")
+	assert.Contains(t, logger.Logs[0].Request, `"reopened_by":{"type":"platform","id":"system"}`)
+}
+
+func TestSendHistoryIsNoop(t *testing.T) {
+	_, rt, _, _ := testsuite.Get()
+
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+	httpx.SetRequestor(httpx.NewMockRequestor(nil))
+
+	ticketer := newTicketer()
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":       svcBaseURL,
+		"api_token":      svcAPIToken,
+		"webhook_secret": svcWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	dbTicket := models.NewTicket("88bfa1dc-be33-45c2-b469-294ecb0eba90", testdata.Org1.ID, testdata.Cathy.ID, testdata.RocketChat.ID, "EXT-X", testdata.DefaultTopic.ID, "x", models.NilUserID, nil)
+	logger := &flows.HTTPLogger{}
+	err = svc.SendHistory(dbTicket, testdata.Cathy.ID, nil, logger.Log)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(logger.Logs))
+}
+
+func TestCustomRoutesThroughConfig(t *testing.T) {
+	_, rt, _, _ := testsuite.Get()
+
+	defer dates.SetNowSource(dates.DefaultNowSource)
+	dates.SetNowSource(dates.NewSequentialNowSource(time.Date(2026, 5, 20, 14, 30, 0, 0, time.UTC)))
+
+	session, _, err := test.CreateTestSession("", envs.RedactionPolicyNone)
+	require.NoError(t, err)
+
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+	uuids.SetGenerator(uuids.NewSeededGenerator(22222))
+	defer httpx.SetRequestor(httpx.DefaultRequestor)
+
+	httpx.SetRequestor(httpx.NewMockRequestor(map[string][]httpx.MockResponse{
+		svcBaseURL + "/api/conversations": {
+			httpx.NewMockResponse(201, nil, `{"external_id":"EXT-ROUTE-1","status":"open","created_at":"2026-05-20T14:30:00Z"}`),
+		},
+	}))
+
+	ticketer := newTicketer()
+	svc, err := generic.NewService(rt.Config, http.DefaultClient, nil, ticketer, map[string]string{
+		"base_url":       svcBaseURL,
+		"api_token":      svcAPIToken,
+		"webhook_secret": svcWebhookSecret,
+		"route_open":     "/api/conversations",
+	})
+	require.NoError(t, err)
+
+	defaultTopic := newDefaultTopic()
+
+	logger := &flows.HTTPLogger{}
+	ticket, err := svc.Open(session, defaultTopic, "test", nil, logger.Log)
+	require.NoError(t, err)
+	require.NotNil(t, ticket)
+	assert.Equal(t, "EXT-ROUTE-1", ticket.ExternalID())
+	require.Equal(t, 1, len(logger.Logs))
+	assert.Contains(t, logger.Logs[0].Request, "POST /api/conversations ")
+}

--- a/services/tickets/generic/web.go
+++ b/services/tickets/generic/web.go
@@ -1,0 +1,30 @@
+package generic
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
+	"github.com/nyaruka/mailroom/web"
+)
+
+func init() {
+	base := "/mr/tickets/types/" + typeGeneric + "/event_callback/{ticketer:[a-f0-9\\-]+}"
+
+	web.RegisterJSONRoute(http.MethodPost, base+"/messages", web.WithHTTPLogs(handleAgentMessage))
+	web.RegisterJSONRoute(http.MethodPost, base+"/tickets/close", web.WithHTTPLogs(handleCloseTicket))
+	web.RegisterJSONRoute(http.MethodPost, base+"/tickets/reopen", web.WithHTTPLogs(handleReopenTicket))
+}
+
+func handleAgentMessage(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+	return map[string]string{"status": "not_implemented"}, http.StatusNotImplemented, nil
+}
+
+func handleCloseTicket(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+	return map[string]string{"status": "not_implemented"}, http.StatusNotImplemented, nil
+}
+
+func handleReopenTicket(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+	return map[string]string{"status": "not_implemented"}, http.StatusNotImplemented, nil
+}

--- a/services/tickets/generic/web.go
+++ b/services/tickets/generic/web.go
@@ -1,12 +1,41 @@
 package generic
 
 import (
+	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/go-chi/chi"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/runtime"
+	"github.com/nyaruka/mailroom/services/tickets"
 	"github.com/nyaruka/mailroom/web"
+	"github.com/pkg/errors"
+)
+
+// Webhook header names (see docs/generic-ticketer-service.md section 1.2).
+const (
+	headerSignature = "X-Webhook-Signature"
+	headerTimestamp = "X-Webhook-Timestamp"
+	signaturePrefix = "sha256="
+
+	// replayWindow is the maximum age accepted on X-Webhook-Timestamp before
+	// the request is rejected as a possible replay.
+	replayWindow = 5 * time.Minute
+
+	// maxWebhookBodyBytes caps the body size we read from a partner webhook.
+	// Generous enough for messages with metadata; tightened from the global
+	// MaxRequestBytes (32MB) since these payloads should be small.
+	maxWebhookBodyBytes = int64(1 << 20) // 1MB
 )
 
 func init() {
@@ -17,14 +46,238 @@ func init() {
 	web.RegisterJSONRoute(http.MethodPost, base+"/tickets/reopen", web.WithHTTPLogs(handleReopenTicket))
 }
 
+// agentMessagePayload mirrors docs/generic-ticketer-service.md section 3.1.
+type agentMessagePayload struct {
+	ExternalID        string                 `json:"external_id"          validate:"required"`
+	MessageExternalID string                 `json:"message_external_id"`
+	Direction         string                 `json:"direction"`
+	Sender            *Sender                `json:"sender"`
+	Text              string                 `json:"text"`
+	Attachments       []Attachment           `json:"attachments"`
+	Metadata          map[string]interface{} `json:"metadata"`
+	SentAt            time.Time              `json:"sent_at"`
+}
+
+// closeTicketPayload mirrors docs/generic-ticketer-service.md section 3.2.
+type closeTicketPayload struct {
+	ExternalID string                 `json:"external_id"        validate:"required"`
+	ClosedBy   *ActorRef              `json:"closed_by"`
+	Reason     string                 `json:"reason"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	ClosedAt   time.Time              `json:"closed_at"`
+}
+
+// reopenTicketPayload mirrors docs/generic-ticketer-service.md section 3.3.
+type reopenTicketPayload struct {
+	ExternalID string                 `json:"external_id"          validate:"required"`
+	ReopenedBy *ActorRef              `json:"reopened_by"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	ReopenedAt time.Time              `json:"reopened_at"`
+}
+
+// errBody is the standard error envelope echoed back to the partner. It
+// matches the format documented in section 9 of the spec so partners get
+// consistent shapes whether the error originated on their side or ours.
+func errBody(code, message string) map[string]interface{} {
+	return map[string]interface{}{"error": code, "message": message}
+}
+
+// readWebhook reads the raw body, verifies the HMAC signature against the
+// ticketer's webhook_secret, validates the timestamp, then returns the
+// ticketer record and the raw body bytes for further JSON parsing. Any
+// failure returns a status code + error envelope ready to be returned from a
+// handler.
+func readWebhook(ctx context.Context, rt *runtime.Runtime, r *http.Request) (*models.Ticketer, []byte, interface{}, int) {
+	ticketerUUID := assets.TicketerUUID(chi.URLParam(r, "ticketer"))
+
+	ticketer, _, err := tickets.FromTicketerUUID(ctx, rt, ticketerUUID, typeGeneric)
+	if err != nil {
+		return nil, nil, errBody("ticketer_not_found", "no such ticketer"), http.StatusNotFound
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxWebhookBodyBytes+1))
+	if err != nil {
+		return nil, nil, errBody("invalid_request", "unable to read request body"), http.StatusBadRequest
+	}
+	if int64(len(body)) > maxWebhookBodyBytes {
+		return nil, nil, errBody("payload_too_large", "request body exceeds limit"), http.StatusRequestEntityTooLarge
+	}
+
+	secret := ticketer.Config(configWebhookSecret)
+	if secret == "" {
+		return nil, nil, errBody("misconfigured", "ticketer has no webhook secret"), http.StatusInternalServerError
+	}
+
+	if !verifySignature(secret, body, r.Header.Get(headerSignature)) {
+		return nil, nil, errBody("invalid_signature", "HMAC verification failed"), http.StatusUnauthorized
+	}
+
+	if ts := r.Header.Get(headerTimestamp); ts != "" {
+		if !verifyTimestamp(ts, time.Now()) {
+			return nil, nil, errBody("expired_request", "X-Webhook-Timestamp outside the accepted window"), http.StatusUnauthorized
+		}
+	}
+
+	return ticketer, body, nil, 0
+}
+
+// verifySignature checks the HMAC-SHA256 of body against the value in the
+// X-Webhook-Signature header. The header may be given as `sha256=<hex>` or
+// `<hex>`; both forms are accepted. Returns false when secret or signature is
+// missing.
+func verifySignature(secret string, body []byte, signatureHeader string) bool {
+	if secret == "" || signatureHeader == "" {
+		return false
+	}
+	provided := strings.TrimPrefix(signatureHeader, signaturePrefix)
+	provided = strings.TrimSpace(provided)
+	if provided == "" {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	// Constant-time comparison guards against timing attacks.
+	return hmac.Equal([]byte(expected), []byte(strings.ToLower(provided)))
+}
+
+// verifyTimestamp accepts either RFC3339 timestamps (preferred per spec) or
+// unix seconds expressed as a numeric string. Returns false when the value
+// can't be parsed or falls outside replayWindow centered on `now`.
+func verifyTimestamp(tsHeader string, now time.Time) bool {
+	t, err := time.Parse(time.RFC3339, tsHeader)
+	if err != nil {
+		secs, parseErr := strconv.ParseInt(tsHeader, 10, 64)
+		if parseErr != nil || secs == 0 {
+			return false
+		}
+		t = time.Unix(secs, 0)
+	}
+	delta := now.Sub(t)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= replayWindow
+}
+
+// handleAgentMessage processes outgoing messages from the partner (an agent
+// reply) and dispatches them to the contact via tickets.SendReply.
 func handleAgentMessage(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
-	return map[string]string{"status": "not_implemented"}, http.StatusNotImplemented, nil
+	ticketer, body, errResp, status := readWebhook(ctx, rt, r)
+	if errResp != nil {
+		return errResp, status, nil
+	}
+
+	payload := &agentMessagePayload{}
+	if err := utils.UnmarshalAndValidateWithLimit(io.NopCloser(bytes.NewReader(body)), payload, maxWebhookBodyBytes); err != nil {
+		return errBody("invalid_payload", err.Error()), http.StatusBadRequest, nil
+	}
+
+	if strings.TrimSpace(payload.Text) == "" && len(payload.Attachments) == 0 {
+		return errBody("empty_message", "text or attachments are required"), http.StatusBadRequest, nil
+	}
+
+	ticket, err := models.LookupTicketByExternalID(ctx, rt.DB, ticketer.ID(), payload.ExternalID)
+	if err != nil || ticket == nil {
+		return errBody("ticket_not_found", "no such ticket for the given external_id"), http.StatusNotFound, nil
+	}
+
+	files := make([]*tickets.File, 0, len(payload.Attachments))
+	for _, att := range payload.Attachments {
+		if att.URL == "" {
+			continue
+		}
+		f, err := tickets.FetchFile(att.URL, nil)
+		if err != nil {
+			return errBody("attachment_fetch_failed", errors.Wrapf(err, "failed fetching %s", att.URL).Error()), http.StatusBadGateway, nil
+		}
+		files = append(files, f)
+	}
+
+	msg, err := tickets.SendReply(ctx, rt, ticket, payload.Text, files, nil)
+	if err != nil {
+		return errBody("send_failed", err.Error()), http.StatusInternalServerError, nil
+	}
+
+	resp := map[string]interface{}{
+		"status":      "sent",
+		"ticket_uuid": ticket.UUID(),
+	}
+	if msg != nil {
+		resp["message_uuid"] = msg.UUID()
+	}
+	return resp, http.StatusOK, nil
 }
 
+// handleCloseTicket marks the ticket closed on the platform side after
+// receiving a close notification from the partner.
 func handleCloseTicket(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
-	return map[string]string{"status": "not_implemented"}, http.StatusNotImplemented, nil
+	ticketer, body, errResp, status := readWebhook(ctx, rt, r)
+	if errResp != nil {
+		return errResp, status, nil
+	}
+
+	payload := &closeTicketPayload{}
+	if err := utils.UnmarshalAndValidateWithLimit(io.NopCloser(bytes.NewReader(body)), payload, maxWebhookBodyBytes); err != nil {
+		return errBody("invalid_payload", err.Error()), http.StatusBadRequest, nil
+	}
+
+	ticket, err := models.LookupTicketByExternalID(ctx, rt.DB, ticketer.ID(), payload.ExternalID)
+	if err != nil || ticket == nil {
+		return errBody("ticket_not_found", "no such ticket for the given external_id"), http.StatusNotFound, nil
+	}
+
+	if ticket.Status() == models.TicketStatusClosed {
+		// Idempotent: partner can safely retry.
+		return map[string]interface{}{"status": "closed", "ticket_uuid": ticket.UUID()}, http.StatusOK, nil
+	}
+
+	oa, err := models.GetOrgAssets(ctx, rt, ticket.OrgID())
+	if err != nil {
+		return errBody("internal", err.Error()), http.StatusInternalServerError, nil
+	}
+
+	// externally=true so we don't notify the partner back (they're the source
+	// of truth for this close event).
+	if err := tickets.Close(ctx, rt, oa, ticket, true, l, string(body)); err != nil {
+		return errBody("close_failed", err.Error()), http.StatusInternalServerError, nil
+	}
+
+	return map[string]interface{}{"status": "closed", "ticket_uuid": ticket.UUID()}, http.StatusOK, nil
 }
 
+// handleReopenTicket reopens the ticket on the platform side after receiving
+// a reopen notification from the partner.
 func handleReopenTicket(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
-	return map[string]string{"status": "not_implemented"}, http.StatusNotImplemented, nil
+	ticketer, body, errResp, status := readWebhook(ctx, rt, r)
+	if errResp != nil {
+		return errResp, status, nil
+	}
+
+	payload := &reopenTicketPayload{}
+	if err := utils.UnmarshalAndValidateWithLimit(io.NopCloser(bytes.NewReader(body)), payload, maxWebhookBodyBytes); err != nil {
+		return errBody("invalid_payload", err.Error()), http.StatusBadRequest, nil
+	}
+
+	ticket, err := models.LookupTicketByExternalID(ctx, rt.DB, ticketer.ID(), payload.ExternalID)
+	if err != nil || ticket == nil {
+		return errBody("ticket_not_found", "no such ticket for the given external_id"), http.StatusNotFound, nil
+	}
+
+	if ticket.Status() == models.TicketStatusOpen {
+		return map[string]interface{}{"status": "open", "ticket_uuid": ticket.UUID()}, http.StatusOK, nil
+	}
+
+	oa, err := models.GetOrgAssets(ctx, rt, ticket.OrgID())
+	if err != nil {
+		return errBody("internal", err.Error()), http.StatusInternalServerError, nil
+	}
+
+	if err := tickets.Reopen(ctx, rt, oa, ticket, true, l); err != nil {
+		return errBody("reopen_failed", err.Error()), http.StatusInternalServerError, nil
+	}
+
+	return map[string]interface{}{"status": "open", "ticket_uuid": ticket.UUID()}, http.StatusOK, nil
 }

--- a/services/tickets/generic/web.go
+++ b/services/tickets/generic/web.go
@@ -103,18 +103,20 @@ func readWebhook(ctx context.Context, rt *runtime.Runtime, r *http.Request) (*mo
 		return nil, nil, errBody("payload_too_large", "request body exceeds limit"), http.StatusRequestEntityTooLarge
 	}
 
-	secret := ticketer.Config(configWebhookSecret)
-	if secret == "" {
-		return nil, nil, errBody("misconfigured", "ticketer has no webhook secret"), http.StatusInternalServerError
-	}
+	if !skipWebhookHMACValue(ticketer.Config(configSkipWebhookHMAC)) {
+		secret := ticketer.Config(configWebhookSecret)
+		if secret == "" {
+			return nil, nil, errBody("misconfigured", "ticketer has no webhook secret"), http.StatusInternalServerError
+		}
 
-	if !verifySignature(secret, body, r.Header.Get(headerSignature)) {
-		return nil, nil, errBody("invalid_signature", "HMAC verification failed"), http.StatusUnauthorized
-	}
+		if !verifySignature(secret, body, r.Header.Get(headerSignature)) {
+			return nil, nil, errBody("invalid_signature", "HMAC verification failed"), http.StatusUnauthorized
+		}
 
-	if ts := r.Header.Get(headerTimestamp); ts != "" {
-		if !verifyTimestamp(ts, time.Now()) {
-			return nil, nil, errBody("expired_request", "X-Webhook-Timestamp outside the accepted window"), http.StatusUnauthorized
+		if ts := r.Header.Get(headerTimestamp); ts != "" {
+			if !verifyTimestamp(ts, time.Now()) {
+				return nil, nil, errBody("expired_request", "X-Webhook-Timestamp outside the accepted window"), http.StatusUnauthorized
+			}
 		}
 	}
 

--- a/services/tickets/generic/web_handlers_test.go
+++ b/services/tickets/generic/web_handlers_test.go
@@ -30,7 +30,7 @@ import (
 // We first realign the id sequence with MAX(id) because the shared test DB
 // dump can have its sequence trail behind the existing rows, which would
 // otherwise make the INSERT collide on the primary key.
-func seedTicketer(t *testing.T, db *sqlx.DB, secret string) assets.TicketerUUID {
+func seedTicketer(t *testing.T, db *sqlx.DB, secret string, skipWebhookHMAC bool) assets.TicketerUUID {
 	t.Helper()
 	u := assets.TicketerUUID(uuids.New())
 
@@ -40,9 +40,13 @@ func seedTicketer(t *testing.T, db *sqlx.DB, secret string) assets.TicketerUUID 
 	)`)
 
 	config := fmt.Sprintf(
-		`{"base_url":"https://partner.example.com","api_token":"x","webhook_secret":%q}`,
+		`{"base_url":"https://partner.example.com","api_token":"x","webhook_secret":%q`,
 		secret,
 	)
+	if skipWebhookHMAC {
+		config += `,"skip_webhook_hmac":"true"`
+	}
+	config += "}"
 	db.MustExec(
 		`INSERT INTO tickets_ticketer(uuid, org_id, name, ticketer_type, config, is_active, created_on, modified_on, created_by_id, modified_by_id)
 		 VALUES ($1, 1, 'Generic Test', 'generic', $2, TRUE, NOW(), NOW(), 1, 1)`,
@@ -96,7 +100,7 @@ func TestHandleAgentMessage_TicketerNotFound(t *testing.T) {
 func TestHandleAgentMessage_InvalidSignature(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
-	u := seedTicketer(t, db, "real-secret")
+	u := seedTicketer(t, db, "real-secret", false)
 
 	body := `{"external_id":"EXT-1","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
 	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, "sha256=deadbeef", ""), &models.HTTPLogger{})
@@ -110,7 +114,7 @@ func TestHandleAgentMessage_InvalidSignature(t *testing.T) {
 func TestHandleAgentMessage_MissingSignature(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
-	u := seedTicketer(t, db, "real-secret")
+	u := seedTicketer(t, db, "real-secret", false)
 
 	body := `{"external_id":"EXT-1","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
 	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, "", ""), &models.HTTPLogger{})
@@ -121,11 +125,25 @@ func TestHandleAgentMessage_MissingSignature(t *testing.T) {
 	assert.Equal(t, "invalid_signature", m["error"])
 }
 
+func TestHandleAgentMessage_SkipHMACAcceptsUnsignedRequest(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	u := seedTicketer(t, db, "", true)
+
+	body := `{"external_id":"DOES-NOT-EXIST","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, "", ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "ticket_not_found", m["error"])
+}
+
 func TestHandleAgentMessage_ExpiredTimestamp(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
 	const secret = "real-secret"
-	u := seedTicketer(t, db, secret)
+	u := seedTicketer(t, db, secret, false)
 
 	body := `{"external_id":"EXT-1","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
 	sig := "sha256=" + computeSig(secret, body)
@@ -144,7 +162,7 @@ func TestHandleAgentMessage_InvalidJSON(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
 	const secret = "real-secret"
-	u := seedTicketer(t, db, secret)
+	u := seedTicketer(t, db, secret, false)
 
 	body := `not json`
 	sig := "sha256=" + computeSig(secret, body)
@@ -160,7 +178,7 @@ func TestHandleAgentMessage_EmptyMessage(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
 	const secret = "real-secret"
-	u := seedTicketer(t, db, secret)
+	u := seedTicketer(t, db, secret, false)
 
 	// Valid JSON but no text and no attachments — rejected as empty
 	body := `{"external_id":"EXT-1","sent_at":"2026-05-20T14:30:00Z"}`
@@ -177,7 +195,7 @@ func TestHandleAgentMessage_TicketNotFound(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
 	const secret = "real-secret"
-	u := seedTicketer(t, db, secret)
+	u := seedTicketer(t, db, secret, false)
 
 	body := `{"external_id":"DOES-NOT-EXIST","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
 	sig := "sha256=" + computeSig(secret, body)
@@ -193,7 +211,7 @@ func TestHandleCloseTicket_TicketNotFound(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
 	const secret = "real-secret"
-	u := seedTicketer(t, db, secret)
+	u := seedTicketer(t, db, secret, false)
 
 	body := `{"external_id":"DOES-NOT-EXIST","closed_at":"2026-05-20T14:30:00Z"}`
 	sig := "sha256=" + computeSig(secret, body)
@@ -209,7 +227,7 @@ func TestHandleReopenTicket_TicketNotFound(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
 	const secret = "real-secret"
-	u := seedTicketer(t, db, secret)
+	u := seedTicketer(t, db, secret, false)
 
 	body := `{"external_id":"DOES-NOT-EXIST","reopened_at":"2026-05-20T14:30:00Z"}`
 	sig := "sha256=" + computeSig(secret, body)

--- a/services/tickets/generic/web_handlers_test.go
+++ b/services/tickets/generic/web_handlers_test.go
@@ -1,0 +1,222 @@
+package generic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/jmoiron/sqlx"
+	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/testsuite"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedTicketer inserts a generic-type ticketer row directly via SQL. We
+// avoid the testdata helpers because the codebase doesn't ship a
+// testdata.Generic constant and the dump shared across tests doesn't include
+// a generic ticketer. The row is removed by t.Cleanup so tests stay
+// isolated.
+//
+// We first realign the id sequence with MAX(id) because the shared test DB
+// dump can have its sequence trail behind the existing rows, which would
+// otherwise make the INSERT collide on the primary key.
+func seedTicketer(t *testing.T, db *sqlx.DB, secret string) assets.TicketerUUID {
+	t.Helper()
+	u := assets.TicketerUUID(uuids.New())
+
+	db.MustExec(`SELECT setval(
+		'tickets_ticketer_id_seq',
+		GREATEST(COALESCE((SELECT MAX(id) FROM tickets_ticketer), 1), 1)
+	)`)
+
+	config := fmt.Sprintf(
+		`{"base_url":"https://partner.example.com","api_token":"x","webhook_secret":%q}`,
+		secret,
+	)
+	db.MustExec(
+		`INSERT INTO tickets_ticketer(uuid, org_id, name, ticketer_type, config, is_active, created_on, modified_on, created_by_id, modified_by_id)
+		 VALUES ($1, 1, 'Generic Test', 'generic', $2, TRUE, NOW(), NOW(), 1, 1)`,
+		u, config,
+	)
+	t.Cleanup(func() {
+		db.MustExec(`DELETE FROM tickets_ticketer WHERE uuid = $1`, u)
+	})
+	return u
+}
+
+// makeReq builds an http.Request preloaded with the chi URL param so the
+// handler sees a routed-style request.
+func makeReq(method, body string, ticketerUUID assets.TicketerUUID, sig, ts string) *http.Request {
+	r := httptest.NewRequest(method, "http://test/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	if sig != "" {
+		r.Header.Set(headerSignature, sig)
+	}
+	if ts != "" {
+		r.Header.Set(headerTimestamp, ts)
+	}
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("ticketer", string(ticketerUUID))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	return r
+}
+
+func decodeResp(t *testing.T, resp interface{}) map[string]interface{} {
+	t.Helper()
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+	out := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(raw, &out))
+	return out
+}
+
+func TestHandleAgentMessage_TicketerNotFound(t *testing.T) {
+	ctx, rt, _, _ := testsuite.Get()
+
+	body := `{"external_id":"any","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
+	bogus := assets.TicketerUUID("00000000-0000-0000-0000-000000000000")
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, bogus, "sha256=deadbeef", ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "ticketer_not_found", m["error"])
+}
+
+func TestHandleAgentMessage_InvalidSignature(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	u := seedTicketer(t, db, "real-secret")
+
+	body := `{"external_id":"EXT-1","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, "sha256=deadbeef", ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "invalid_signature", m["error"])
+}
+
+func TestHandleAgentMessage_MissingSignature(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	u := seedTicketer(t, db, "real-secret")
+
+	body := `{"external_id":"EXT-1","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, "", ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "invalid_signature", m["error"])
+}
+
+func TestHandleAgentMessage_ExpiredTimestamp(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	const secret = "real-secret"
+	u := seedTicketer(t, db, secret)
+
+	body := `{"external_id":"EXT-1","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
+	sig := "sha256=" + computeSig(secret, body)
+	// 10 minutes in the past — outside the 5-minute window
+	ts := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, sig, ts), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "expired_request", m["error"])
+}
+
+func TestHandleAgentMessage_InvalidJSON(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	const secret = "real-secret"
+	u := seedTicketer(t, db, secret)
+
+	body := `not json`
+	sig := "sha256=" + computeSig(secret, body)
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, sig, ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "invalid_payload", m["error"])
+}
+
+func TestHandleAgentMessage_EmptyMessage(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	const secret = "real-secret"
+	u := seedTicketer(t, db, secret)
+
+	// Valid JSON but no text and no attachments — rejected as empty
+	body := `{"external_id":"EXT-1","sent_at":"2026-05-20T14:30:00Z"}`
+	sig := "sha256=" + computeSig(secret, body)
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, sig, ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "empty_message", m["error"])
+}
+
+func TestHandleAgentMessage_TicketNotFound(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	const secret = "real-secret"
+	u := seedTicketer(t, db, secret)
+
+	body := `{"external_id":"DOES-NOT-EXIST","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
+	sig := "sha256=" + computeSig(secret, body)
+	resp, status, err := handleAgentMessage(ctx, rt, makeReq("POST", body, u, sig, ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "ticket_not_found", m["error"])
+}
+
+func TestHandleCloseTicket_TicketNotFound(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	const secret = "real-secret"
+	u := seedTicketer(t, db, secret)
+
+	body := `{"external_id":"DOES-NOT-EXIST","closed_at":"2026-05-20T14:30:00Z"}`
+	sig := "sha256=" + computeSig(secret, body)
+	resp, status, err := handleCloseTicket(ctx, rt, makeReq("POST", body, u, sig, ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "ticket_not_found", m["error"])
+}
+
+func TestHandleReopenTicket_TicketNotFound(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	const secret = "real-secret"
+	u := seedTicketer(t, db, secret)
+
+	body := `{"external_id":"DOES-NOT-EXIST","reopened_at":"2026-05-20T14:30:00Z"}`
+	sig := "sha256=" + computeSig(secret, body)
+	resp, status, err := handleReopenTicket(ctx, rt, makeReq("POST", body, u, sig, ""), &models.HTTPLogger{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, status)
+	m := decodeResp(t, resp)
+	assert.Equal(t, "ticket_not_found", m["error"])
+}

--- a/services/tickets/generic/web_internal_test.go
+++ b/services/tickets/generic/web_internal_test.go
@@ -1,0 +1,80 @@
+package generic
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// computeSig mirrors what a partner would do to produce a valid
+// X-Webhook-Signature header.
+func computeSig(secret, body string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifySignature(t *testing.T) {
+	const (
+		secret = "shh-its-a-secret"
+		body   = `{"external_id":"EXT-1","direction":"outgoing","text":"hi","sent_at":"2026-05-20T14:30:00Z"}`
+	)
+	good := computeSig(secret, body)
+
+	cases := []struct {
+		name      string
+		secret    string
+		body      string
+		signature string
+		want      bool
+	}{
+		{"valid with sha256 prefix", secret, body, "sha256=" + good, true},
+		{"valid without prefix", secret, body, good, true},
+		{"uppercase hex still accepted", secret, body, "sha256=" + strings.ToUpper(good), true},
+		{"trailing whitespace tolerated", secret, body, "sha256=" + good + " ", true},
+		{"wrong secret rejected", "other", body, "sha256=" + good, false},
+		{"tampered body rejected", secret, body + "!", "sha256=" + good, false},
+		{"empty signature header rejected", secret, body, "", false},
+		{"empty secret rejected", "", body, "sha256=" + good, false},
+		{"prefix only rejected", secret, body, "sha256=", false},
+		{"garbage hex rejected", secret, body, "sha256=" + strings.Repeat("z", len(good)), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, verifySignature(tc.secret, []byte(tc.body), tc.signature))
+		})
+	}
+}
+
+func TestVerifyTimestamp(t *testing.T) {
+	now := time.Date(2026, 5, 20, 14, 30, 0, 0, time.UTC)
+	nowUnix := strconv.FormatInt(now.Unix(), 10)
+	expiredUnix := strconv.FormatInt(now.Add(-6*time.Minute).Unix(), 10)
+
+	cases := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"now in RFC3339", now.Format(time.RFC3339), true},
+		{"5 min in the past", now.Add(-5 * time.Minute).Format(time.RFC3339), true},
+		{"5 min in the future", now.Add(5 * time.Minute).Format(time.RFC3339), true},
+		{"6 min in the past", now.Add(-6 * time.Minute).Format(time.RFC3339), false},
+		{"6 min in the future", now.Add(6 * time.Minute).Format(time.RFC3339), false},
+		{"unix seconds now", nowUnix, true},
+		{"unix seconds expired", expiredUnix, false},
+		{"empty", "", false},
+		{"not a date", "garbage", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, verifyTimestamp(tc.header, now))
+		})
+	}
+}


### PR DESCRIPTION
**Summary**
Adds a generic HTTP ticketer to Mailroom so external partners can integrate without custom Mailroom code

**Changes**

- Outbound: open, forward, close, and reopen tickets via configurable HTTP routes (base_url, api_token, optional route overrides)

- Inbound webhooks: agent messages, close, and reopen at /mr/tickets/types/generic/event_callback/{ticketer}/...

- Security: Bearer auth, HMAC-SHA256 webhooks, replay protection; skip_webhook_hmac optional for dev

- Resilience: idempotency keys; 409 on open reuses external_id; 409 on close treated as already closed

- SendHistory: no-op for now (follow-up)