### PR TITLE
feat: add marketing opt-in functionality with tests and database integration

### DIFF
--- a/WENI-CHANGELOG.md
+++ b/WENI-CHANGELOG.md
@@ -1,3 +1,7 @@
+1.93.0
+----------
+* feat: add marketing opt-in functionality with tests and database integration
+
 1.92.0
 ----------
 * feat: add generic ticketer

--- a/core/models/fields_test.go
+++ b/core/models/fields_test.go
@@ -110,6 +110,9 @@ func TestGetOrCreateContactField(t *testing.T) {
 		err = models.GetOrCreateContactField(ctx, db, orgID, "vtex_account", "Vtex account")
 		require.NoError(t, err)
 
+		err = models.GetOrCreateContactField(ctx, db, orgID, "marketing_opt_in", "Marketing opt-in")
+		require.NoError(t, err)
+
 		testsuite.AssertQuery(t, db,
 			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'orderform' AND is_active = TRUE`,
 			orgID,
@@ -138,5 +141,6 @@ func TestGetOrCreateContactField(t *testing.T) {
 		assert.NotNil(t, oa.FieldByKey("email"))
 		assert.NotNil(t, oa.FieldByKey("session"))
 		assert.NotNil(t, oa.FieldByKey("vtex_account"))
+		assert.NotNil(t, oa.FieldByKey("marketing_opt_in"))
 	})
 }

--- a/core/models/marketing_opt_in.go
+++ b/core/models/marketing_opt_in.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"context"
+	"strings"
+
+	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/mailroom/runtime"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const MarketingOptInFieldKey = "marketing_opt_in"
+
+// IsMarketingTemplateCategory reports whether a template category is MARKETING.
+func IsMarketingTemplateCategory(category string) bool {
+	return strings.EqualFold(strings.TrimSpace(category), "marketing")
+}
+
+// ContactAllowsMarketing returns whether the contact may receive marketing template messages.
+// Missing or empty field values are treated as opt-in (allow marketing).
+func ContactAllowsMarketing(c *Contact) bool {
+	if c == nil {
+		return true
+	}
+	fieldVal, ok := c.Fields()[MarketingOptInFieldKey]
+	if !ok || fieldVal == nil {
+		return true
+	}
+	return !isMarketingOptOutValue(fieldVal)
+}
+
+func isMarketingOptOutValue(v *flows.Value) bool {
+	if v == nil {
+		return false
+	}
+	s := strings.ToLower(strings.TrimSpace(v.Text.Native()))
+	switch s {
+	case "false", "no", "0", "n":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyMarketingOptOutFailure marks the outgoing message as failed when the contact opted out of marketing templates.
+// contact may be passed when the caller already loaded it (e.g. WPP broadcast batch); otherwise it is loaded from the DB.
+func applyMarketingOptOutFailure(ctx context.Context, rt *runtime.Runtime, org *Org, msg *Msg, category string, contact *Contact) error {
+	if msg.m.Status != MsgStatusQueued || category == "" || !IsMarketingTemplateCategory(category) {
+		return nil
+	}
+
+	c := contact
+	if c == nil {
+		oa, err := GetOrgAssets(ctx, rt, org.ID())
+		if err != nil {
+			return errors.Wrap(err, "error loading org assets for marketing opt-in check")
+		}
+
+		contacts, err := LoadContactsBasic(ctx, rt.DB, oa, []ContactID{msg.m.ContactID})
+		if err != nil {
+			return errors.Wrap(err, "error loading contact for marketing opt-in check")
+		}
+		if len(contacts) == 0 {
+			return nil
+		}
+		c = contacts[0]
+	}
+
+	if ContactAllowsMarketing(c) {
+		return nil
+	}
+
+	msg.m.Status = MsgStatusFailed
+	msg.m.FailedReason = MsgFailedMarketingOptOut
+	logrus.WithFields(logrus.Fields{
+		"org_id":       org.ID(),
+		"contact_id":   msg.m.ContactID,
+		"broadcast_id": msg.m.BroadcastID,
+	}).Info("marketing template not sent due to contact opt-out")
+	return nil
+}

--- a/core/models/marketing_opt_in_broadcast_test.go
+++ b/core/models/marketing_opt_in_broadcast_test.go
@@ -1,0 +1,93 @@
+package models_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWppBroadcastMarketingOptOut(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+	defer testsuite.Reset(testsuite.ResetData)
+
+	db.MustExec(`UPDATE contacts_contacturn SET identity = 'whatsapp:559899999999', path='559899999999', scheme='whatsapp' WHERE contact_id = $1`, testdata.Alexandria.ID)
+	db.MustExec(`UPDATE contacts_contact SET language='eng' WHERE id = $1`, testdata.Alexandria.ID)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdata.Org1.ID)
+	require.NoError(t, err)
+
+	templates, err := oa.Templates()
+	require.NoError(t, err)
+	require.True(t, len(templates) > 2)
+
+	welcome := templates[2]
+	db.MustExec(`UPDATE templates_template SET category = 'marketing' WHERE org_id = $1 AND uuid = $2`, testdata.Org1.ID, welcome.UUID())
+
+	oa, err = models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshTemplates)
+	require.NoError(t, err)
+
+	templateMsg := models.WppBroadcastMessage{
+		Text: "hello @contact.name",
+		Template: models.WppBroadcastTemplate{
+			UUID:      welcome.UUID(),
+			Name:      welcome.Name(),
+			Variables: []string{"@contact.name"},
+			Locale:    "eng",
+		},
+	}
+
+	makeBroadcast := func() *models.WppBroadcast {
+		return models.NewWppBroadcast(
+			oa.OrgID(),
+			models.NilBroadcastID,
+			templateMsg,
+			[]urns.URN{urns.URN("whatsapp:559899999999")},
+			nil,
+			nil,
+			testdata.WhatsAppCloudChannel.ID,
+			"batch",
+		)
+	}
+
+	t.Run("contact without marketing_opt_in receives queued message", func(t *testing.T) {
+		bcast := makeBroadcast()
+		batch := bcast.CreateBatch([]models.ContactID{testdata.Alexandria.ID})
+
+		msgs, err := models.CreateWppBroadcastMessages(ctx, rt, oa, batch)
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, models.MsgStatusQueued, msgs[0].Status())
+	})
+
+	t.Run("contact with marketing_opt_in false gets failed message", func(t *testing.T) {
+		err := models.GetOrCreateContactField(ctx, db, testdata.Org1.ID, models.MarketingOptInFieldKey, "Marketing opt-in")
+		require.NoError(t, err)
+
+		oa, err = models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshFields)
+		require.NoError(t, err)
+
+		field := oa.FieldByKey(models.MarketingOptInFieldKey)
+		require.NotNil(t, field)
+
+		db.MustExec(
+			fmt.Sprintf(`UPDATE contacts_contact SET fields = '{"%s": {"text": "false"}}' WHERE id = $1`, field.UUID()),
+			testdata.Alexandria.ID,
+		)
+		models.FlushCache()
+
+		bcast := makeBroadcast()
+		batch := bcast.CreateBatch([]models.ContactID{testdata.Alexandria.ID})
+
+		msgs, err := models.CreateWppBroadcastMessages(ctx, rt, oa, batch)
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, models.MsgStatusFailed, msgs[0].Status())
+		assert.Equal(t, models.MsgFailedMarketingOptOut, msgs[0].FailedReason())
+	})
+}

--- a/core/models/marketing_opt_in_test.go
+++ b/core/models/marketing_opt_in_test.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/nyaruka/goflow/excellent/types"
+	"github.com/nyaruka/goflow/flows"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMarketingTemplateCategory(t *testing.T) {
+	assert.True(t, IsMarketingTemplateCategory("marketing"))
+	assert.True(t, IsMarketingTemplateCategory("MARKETING"))
+	assert.True(t, IsMarketingTemplateCategory(" Marketing "))
+	assert.False(t, IsMarketingTemplateCategory("utility"))
+	assert.False(t, IsMarketingTemplateCategory(""))
+}
+
+func TestContactAllowsMarketing(t *testing.T) {
+	assert.True(t, ContactAllowsMarketing(nil))
+
+	empty := &Contact{}
+	assert.True(t, ContactAllowsMarketing(empty))
+
+	withFalse := &Contact{
+		fields: map[string]*flows.Value{
+			MarketingOptInFieldKey: flows.NewValue(types.NewXText("false"), nil, nil, "", "", ""),
+		},
+	}
+	assert.False(t, ContactAllowsMarketing(withFalse))
+
+	withNo := &Contact{
+		fields: map[string]*flows.Value{
+			MarketingOptInFieldKey: flows.NewValue(types.NewXText("no"), nil, nil, "", "", ""),
+		},
+	}
+	assert.False(t, ContactAllowsMarketing(withNo))
+
+	withTrue := &Contact{
+		fields: map[string]*flows.Value{
+			MarketingOptInFieldKey: flows.NewValue(types.NewXText("true"), nil, nil, "", "", ""),
+		},
+	}
+	assert.True(t, ContactAllowsMarketing(withTrue))
+}

--- a/core/models/msgs.go
+++ b/core/models/msgs.go
@@ -87,6 +87,7 @@ const (
 	MsgFailedTooOld          = MsgFailedReason("O")
 	MsgFailedNoDestination   = MsgFailedReason("D")
 	MsgFailedSuspendTemplate = MsgFailedReason("T")
+	MsgFailedMarketingOptOut = MsgFailedReason("M")
 )
 
 // BroadcastID is our internal type for broadcast ids, which can be null/0
@@ -357,7 +358,7 @@ func NewOutgoingFlowMsgCatalog(rt *runtime.Runtime, org *Org, channel *Channel, 
 
 // NewOutgoingFlowMsgWpp creates an outgoing message for the passed in flow message
 func NewOutgoingFlowMsgWpp(rt *runtime.Runtime, org *Org, channel *Channel, session *Session, out *flows.MsgWppOut, createdOn time.Time) (*Msg, error) {
-	return newOutgoingMsgWpp(rt, org, channel, session.ContactID(), out, createdOn, session, NilBroadcastID, true, nil)
+	return newOutgoingMsgWpp(rt, org, channel, session.ContactID(), out, createdOn, session, NilBroadcastID, true, nil, nil)
 }
 
 // NewOutgoingBroadcastMsg creates an outgoing message which is part of a broadcast
@@ -365,8 +366,8 @@ func NewOutgoingBroadcastMsg(rt *runtime.Runtime, org *Org, channel *Channel, co
 	return newOutgoingMsg(rt, org, channel, contactID, out, createdOn, nil, broadcastID, extraMetadata)
 }
 
-func NewOutgoingWppBroadcastMsg(rt *runtime.Runtime, org *Org, channel *Channel, contactID ContactID, out *flows.MsgWppOut, createdOn time.Time, broadcastID BroadcastID, highPriority bool, extraMetadata map[string]interface{}) (*Msg, error) {
-	return newOutgoingMsgWpp(rt, org, channel, contactID, out, createdOn, nil, broadcastID, highPriority, extraMetadata)
+func NewOutgoingWppBroadcastMsg(rt *runtime.Runtime, org *Org, channel *Channel, contact *Contact, out *flows.MsgWppOut, createdOn time.Time, broadcastID BroadcastID, highPriority bool, extraMetadata map[string]interface{}) (*Msg, error) {
+	return newOutgoingMsgWpp(rt, org, channel, contact.ID(), out, createdOn, nil, broadcastID, highPriority, extraMetadata, contact)
 }
 
 // NewOutgoingMsg creates an outgoing message that does not belong to any flow or broadcast, it's used to the a direct message to the contact
@@ -472,6 +473,10 @@ func newOutgoingMsg(rt *runtime.Runtime, org *Org, channel *Channel, contactID C
 				m.FailedReason = MsgFailedSuspendTemplate // Suspend Template
 				logrus.WithFields(logrus.Fields{"org_id": org.ID()}).Debug("suspend template, failing message")
 			}
+			if err := applyMarketingOptOutFailure(context.Background(), rt, org, msg, out.Templating().Template().Category, nil); err != nil {
+				return nil, err
+			}
+
 		}
 		if out.Topic() != flows.NilMsgTopic {
 			metadata["topic"] = string(out.Topic())
@@ -593,7 +598,7 @@ func newOutgoingMsgCatalog(rt *runtime.Runtime, org *Org, channel *Channel, cont
 	return msg, nil
 }
 
-func newOutgoingMsgWpp(rt *runtime.Runtime, org *Org, channel *Channel, contactID ContactID, msgWpp *flows.MsgWppOut, createdOn time.Time, session *Session, broadcastID BroadcastID, highPriority bool, extraMetadata map[string]interface{}) (*Msg, error) {
+func newOutgoingMsgWpp(rt *runtime.Runtime, org *Org, channel *Channel, contactID ContactID, msgWpp *flows.MsgWppOut, createdOn time.Time, session *Session, broadcastID BroadcastID, highPriority bool, extraMetadata map[string]interface{}, contact *Contact) (*Msg, error) {
 	msg := &Msg{}
 	m := &msg.m
 	m.UUID = msgWpp.UUID()
@@ -735,6 +740,9 @@ func newOutgoingMsgWpp(rt *runtime.Runtime, org *Org, channel *Channel, contactI
 				m.Status = MsgStatusFailed
 				m.FailedReason = MsgFailedSuspendTemplate // Suspend Template
 				logrus.WithFields(logrus.Fields{"org_id": org.ID()}).Debug("suspend template, failing message")
+			}
+			if err := applyMarketingOptOutFailure(context.Background(), rt, org, msg, msgWpp.Templating().Template().Category, contact); err != nil {
+				return nil, err
 			}
 
 		}
@@ -2068,7 +2076,7 @@ func CreateWppBroadcastMessages(ctx context.Context, rt *runtime.Runtime, oa *Or
 			extraMetadata["product_carousel"] = carousel
 		}
 
-		msg, err := NewOutgoingWppBroadcastMsg(rt, oa.Org(), channel, c.ID(), out, time.Now(), bcast.BroadcastID(), highPriority, extraMetadata)
+		msg, err := NewOutgoingWppBroadcastMsg(rt, oa.Org(), channel, c, out, time.Now(), bcast.BroadcastID(), highPriority, extraMetadata)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating outgoing message")
 		}

--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -775,11 +775,12 @@ func shouldFireTrigger(trigger *models.Trigger, flow *models.Flow, isBrain bool)
 
 // fields that should be auto-created when received but not present in the org
 var autoCreateFieldKeys = map[string]string{
-	"segment":      "Segment",
-	"orderform":    "Orderform",
-	"email":        "Email",
-	"session":      "Session",
-	"vtex_account": "Vtex account",
+	"segment":          "Segment",
+	"orderform":        "Orderform",
+	"email":            "Email",
+	"session":          "Session",
+	"vtex_account":     "Vtex account",
+	"marketing_opt_in": "Marketing opt-in",
 }
 
 // applyContactFieldModifiers creates and applies field modifiers from the event's new contact fields.

--- a/core/tasks/handler/worker_test.go
+++ b/core/tasks/handler/worker_test.go
@@ -558,6 +558,36 @@ func TestApplyContactFieldModifiers(t *testing.T) {
 		assert.Equal(t, assets.FieldTypeText, field.Type())
 	})
 
+	t.Run("marketing_opt_in field is auto-created and applied", func(t *testing.T) {
+		require.Nil(t, oa.SessionAssets().Fields().Get("marketing_opt_in"), "marketing_opt_in field should not exist yet")
+
+		event := &MsgEvent{
+			ContactID:        testdata.Cathy.ID,
+			OrgID:            testdata.Org1.ID,
+			MsgID:            msg.ID(),
+			MsgUUID:          flows.MsgUUID(uuids.New()),
+			NewContactFields: map[string]string{"marketing_opt_in": "false"},
+		}
+
+		modelContact, updatedContact, recalcGroups, err := applyContactFieldModifiers(ctx, rt, oa, event, flowContact, models.NilTopupID)
+		require.NoError(t, err)
+		require.NotNil(t, modelContact)
+		require.NotNil(t, updatedContact)
+		assert.True(t, recalcGroups)
+
+		testsuite.AssertQuery(t, db,
+			`SELECT count(*) FROM contacts_contactfield WHERE org_id = $1 AND key = 'marketing_opt_in' AND is_active = TRUE AND value_type = 'T'`,
+			testdata.Org1.ID,
+		).Returns(1)
+
+		refreshedOA, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshFields)
+		require.NoError(t, err)
+		field := refreshedOA.FieldByKey("marketing_opt_in")
+		require.NotNil(t, field)
+		assert.Equal(t, "Marketing opt-in", field.Name())
+		assert.Equal(t, assets.FieldTypeText, field.Type())
+	})
+
 	t.Run("both whitelisted fields in one event", func(t *testing.T) {
 		db.MustExec(`DELETE FROM contacts_contactfield WHERE org_id = $1 AND key IN ('segment', 'orderform', 'email', 'session', 'vtex_account')`, testdata.Org1.ID)
 		models.FlushCache()


### PR DESCRIPTION
- Implemented marketing opt-in field creation and validation in contact management.
- Added tests for marketing opt-in behavior in WPP broadcasts.
- Updated message handling to respect marketing opt-out status.
- Enhanced existing tests to cover new marketing opt-in scenarios.